### PR TITLE
Add tenets CLI installer and rebrand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,126 @@
-# Agent Context Kit
+# Tenets
 
-Coding standards context for AI agents building backend services with Domain Driven Design and Hexagonal Architecture. 
+The tenets of writing quality backend code -- starting with Hexagonal Architecture and Domain-Driven Design.
+
+**Tenets** provides opinionated, battle-tested rules that your AI coding agents follow when building backend services. Install them with a single command and your agent immediately knows how to structure domains, ports, adapters, and everything in between.
 
 ## 🤖 Why This Exists
 
-AI coding agents like Claude Code, Cursor, and Windsurf can generate incredible amounts of code quickly. But **I still care about the code quality**. We're not at the point where we can be completely hands-off—I constantly review, iterate, and guide these tools toward better implementations.
+AI coding agents like Claude Code, Cursor, and GitHub Copilot can generate incredible amounts of code quickly. But **code quality still matters**. We're not at the point where we can be completely hands-off -- we constantly review, iterate, and guide these tools toward better implementations.
 
 For effective code review and collaboration with AI agents, we need **predictable design patterns**. This is even more crucial with AI-generated code since these tools can produce entire features at once, making architectural consistency vital for maintainability.
 
+Tenets solves this by giving your coding agents the context and rules they need upfront, so every generated line of code follows the same architectural principles your team agreed on.
+
+## 🚀 Quick Start
+
+### Install with the CLI
+
+```bash
+npx tenets init --claude
+```
+
+That's it. The DDD + Hexagonal Architecture tenets are now in your project's `CLAUDE.md`, ready for Claude Code to follow.
+
+### Pick Your Tool
+
+```bash
+npx tenets init --cursor        # writes to .cursorrules
+npx tenets init --copilot       # writes to .github/copilot-instructions.md
+npx tenets init --agents        # writes to AGENTS.md
+npx tenets init --claude        # writes to CLAUDE.md
+```
+
+| Flag | Tool | Target File |
+|------|------|-------------|
+| `--claude` | Claude Code | `CLAUDE.md` |
+| `--cursor` | Cursor | `.cursorrules` |
+| `--copilot` | GitHub Copilot | `.github/copilot-instructions.md` |
+| `--agents` | AGENTS.md | `AGENTS.md` |
+
+### Interactive Mode
+
+Not sure which tool? Just run it without flags and follow the prompts:
+
+```bash
+npx tenets init
+```
+
+The CLI will walk you through selecting your tool and confirming the install.
+
+### Keeping Tenets Up to Date
+
+As Tenets evolves with new patterns and learnings, update your project to the latest version:
+
+```bash
+npx tenets update
+```
+
+This pulls the latest rules and updates the files that were previously installed in your project.
+
 ## 🏗️ What's Inside
 
-These rules are based on years of building backend services using:
+These tenets are based on years of building backend services using:
 
-- **Domain Driven Design (DDD)** - Rich domain models, ubiquitous language, clear boundaries
-- **Hexagonal Architecture (Ports & Adapters)** - Separation of concerns, testability, technology independence
-- **Python Best Practices** - Leveraging Python's strengths while maintaining clean architecture
+- **Domain-Driven Design (DDD)** -- Rich domain models, ubiquitous language, clear bounded contexts
+- **Hexagonal Architecture (Ports & Adapters)** -- Separation of concerns, testability, technology independence
+- **Practical Patterns** -- Aggregate design, domain events, application services, repository contracts, and more
 
-## 🚀 How to Use With AI Agents
+Tenets covers the full spectrum of backend service development:
 
-### Option 1: Direct Context
-Copy the rules into your AI agent's context when starting a new project or feature:
-
-```
-Please follow the architectural rules in this repository when implementing backend services.
-Focus on DDD and Hexagonal Architecture patterns as outlined in the guidelines.
-```
-
-### Option 2: Project-Specific Rules
-Add these rules to your project's documentation and reference them:
-
-```
-Implement this feature following our backend standards: 
-[link to relevant rule sections]
-```
-
-### Option 3: Tool Integration
-Many AI coding tools support project-specific context files:
-- Copy rules to `.cursorrules` for Cursor
-- Add as project context in Claude Code
-- Reference in Windsurf workspace settings
-
+1. **Getting started** with a new service from scratch
+2. **Evolving** an existing service with new features and capabilities
+3. **Building multiple services** that interact with each other
 
 ## 🎯 Language Support
 
-This repository currently focuses on Python implementations, providing concrete examples and patterns optimized for Python's language features and ecosystem.
+Tenets currently focuses on Python implementations, providing concrete examples and patterns optimized for Python's language features and ecosystem.
 
-However, I'd love to collaborate with experts in other languages to expand this into a comprehensive reference for all major backend languages. If you're experienced with Java, C#, Go, TypeScript, or other languages, I welcome contributions that translate these architectural principles into language-specific implementations.
-
-The goal is to make this the go-to reference for backend development standards across the entire ecosystem.
+We'd love to collaborate with experts in other languages to expand coverage. If you're experienced with Java, C#, Go, TypeScript, or other languages, contributions that translate these architectural rules into language-specific implementations are welcome.
 
 ## 🤝 Contributing
 
-This is a living document based on real-world experience, but there's always room for improvement! 
+This is a living set of tenets based on real-world experience, and there's always room for improvement.
 
 ### How to Contribute
 
-1. **Open an Issue** - Propose new rules, improvements, or discuss existing ones
-2. **Submit a PR** - Add new patterns, fix examples, or improve clarity
-3. **Share Examples** - Real-world implementations that follow these patterns
-4. **Language Adaptations** - Help translate patterns to other languages
+1. **Open an Issue** -- Propose new tenets, improvements, or discuss existing ones
+2. **Submit a PR** -- Add new patterns, fix examples, or improve clarity
+3. **Share Examples** -- Real-world implementations that follow Tenets rules
+4. **Language Adaptations** -- Help translate tenets to other languages
 
 ### What We're Looking For
 
-- 🔍 **Uncovered Scenarios** - Backend development situations not yet addressed by the current rules
-- 🎨 **Missing Design Patterns** - Additional patterns that complement DDD and Hexagonal Architecture
-- 🛠️ **Implementation Strategies** - Better approaches for complex scenarios like distributed systems, event sourcing, or CQRS
-- 🧪 **Advanced Testing Patterns** - Testing strategies for complex domain logic and integration scenarios
-- 📊 **Real-World Examples** - Case studies showing these patterns in production systems
+- 🔍 **Uncovered Scenarios** -- Backend development situations not yet addressed by the current tenets
+- 🎨 **Missing Design Patterns** -- Additional patterns that complement DDD and Hexagonal Architecture
+- 🛠️ **Implementation Strategies** -- Better approaches for distributed systems, event sourcing, or CQRS
+- 🧪 **Advanced Testing Patterns** -- Testing strategies for complex domain logic and integration scenarios
+- 📊 **Real-World Examples** -- Case studies showing Tenets rules applied in production systems
 
 ## 🧠 Philosophy
 
-> "I think of AI coding agents as another developer on my team—I expect them to follow the same best practices."
+> "I think of AI coding agents as another developer on my team -- I expect them to follow the same best practices."
 
-These standards ensure that:
+These tenets ensure that:
 
-- **Code is reviewable** - Predictable patterns make AI-generated code easier to understand
-- **Architecture is consistent** - Clear rules prevent architectural drift
-- **Teams can collaborate** - Shared standards improve team efficiency
-- **Systems remain maintainable** - Good architecture scales with your codebase
+- **Code is reviewable** -- Predictable patterns make AI-generated code easier to understand
+- **Architecture is consistent** -- Clear tenets prevent architectural drift across features and services
+- **Teams can collaborate** -- Shared tenets improve team efficiency, whether the author is human or AI
+- **Systems remain maintainable** -- Good architecture scales with your codebase
 
 ## 📚 Additional Resources
 
-- [Medium Article: Why I Still Care About Code Quality with AI Agents](link-to-your-article)
-- [Domain Driven Design by Eric Evans](https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215)
+- [Domain-Driven Design by Eric Evans](https://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215)
 - [Hexagonal Architecture by Alistair Cockburn](https://alistair.cockburn.us/hexagonal-architecture/)
 - [Clean Architecture by Robert Martin](https://www.amazon.com/Clean-Architecture-Craftsmans-Software-Structure/dp/0134494164)
 
 ## 📄 License
 
-MIT License - see [LICENSE](LICENSE) file for details.
+MIT License -- see [LICENSE](LICENSE) file for details.
 
 ## ⭐ Support
 
-If these standards help you build better backend services with AI agents, please:
+If Tenets helps you build better backend services with AI agents, please:
 
 - ⭐ Star this repository
 - 🔗 Share with your team
@@ -101,4 +129,4 @@ If these standards help you build better backend services with AI agents, please
 
 ---
 
-*Let's build better backend services together, one AI-generated feature at a time.*
+*Tenets for better backend services -- one rule at a time.*

--- a/cli/bin/tenets.js
+++ b/cli/bin/tenets.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+const { logger } = require('../src/ui/logger');
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+async function main() {
+  logger.banner();
+
+  switch (command) {
+    case 'init': {
+      const { initCommand } = require('../src/commands/init');
+      await initCommand(args.slice(1));
+      break;
+    }
+    case 'update': {
+      const { updateCommand } = require('../src/commands/update');
+      await updateCommand();
+      break;
+    }
+    case '--help':
+    case '-h':
+    case undefined:
+      printUsage();
+      break;
+    default:
+      logger.error(`Unknown command: ${command}`);
+      printUsage();
+      process.exitCode = 1;
+  }
+}
+
+function printUsage() {
+  console.log(`Usage: tenets <command> [options]
+
+Commands:
+  init              Install rules into your AI tool's config
+  update            Update all installed rules to latest
+
+Init options:
+  --claude          Write to CLAUDE.md
+  --cursor          Write to .cursorrules
+  --copilot         Write to .github/copilot-instructions.md
+  --agents          Write to AGENTS.md
+
+Examples:
+  npx tenets init --claude
+  npx tenets init --cursor
+  npx tenets update`);
+}
+
+main().catch((err) => {
+  logger.error(err.message);
+  process.exitCode = 1;
+});

--- a/cli/bundled/context/01-hexagonal-primer.md
+++ b/cli/bundled/context/01-hexagonal-primer.md
@@ -1,0 +1,12 @@
+# Hexagonal Architecture Primer
+
+Hexagonal architecture, also known as Ports and Adapters, is a design pattern that separates business logic from technical concerns. It aims to isolate the core domain from external systems, making the application more maintainable, testable, and adaptable to change.
+
+This architecture organizes the system into four main components:
+
+- **Domain**: The core business logic and rules, independent of frameworks and technologies.  
+- **Application**: Coordinates domain logic and defines application-specific tasks.  
+- **Ports**: Interfaces that define communication between the application and the outside world.  
+- **Adapters**: Implementations of ports that connect to external systems like databases, APIs, or user interfaces.
+
+See [components.md](./components.md) for detailed responsibilities and checklists.

--- a/cli/bundled/context/02-components.md
+++ b/cli/bundled/context/02-components.md
@@ -1,0 +1,178 @@
+# Components of Hexagonal Architecture
+
+Use hexagonal architecture to separate business logic, application orchestration, and technical concerns. Follow strict dependency rules and component boundaries to ensure modularity, testability, and adaptability.
+
+---
+
+## Domain
+
+**Responsibilities:**  
+- Encapsulate business rules, logic, and invariants.  
+- Represent core concepts, entities, value objects, and aggregates.  
+- Operate independently from external systems, frameworks, or infrastructure.
+
+**Must:**  
+- Contain pure business logic only.  
+- Behave deterministically based on inputs.  
+- Exposes behavior; application may call these, but domain must not depend on application or ports.
+
+**Must Not:**  
+- Depend on application, adapters, ports, or infrastructure.  
+- Leak infrastructure concerns (e.g., database code) into domain logic.  
+- Include technical or framework-specific annotations.  
+- Use domain objects for data transport or serialization.
+
+**Boundaries:**  
+- No dependencies on adapters, frameworks, or external services.  
+- Communicate only through defined ports with the application layer.
+
+---
+
+## Application
+
+**Responsibilities:**  
+- Orchestrate use cases, workflows, and application-specific logic.  
+- Coordinate domain objects to fulfill business requirements.  
+- Manage transactions, security, and authorization if applicable.  
+- Define and expose inbound ports; use outbound ports.
+
+**Must:**  
+- Delegate business logic exclusively to the domain.  
+- Be stateless and idempotent where possible.  
+- Depend only on domain logic and port interfaces.
+
+**Must Not:**  
+- Contain business rules.  
+- Depend on infrastructure or adapter implementations.  
+- Mix application and infrastructure responsibilities.
+
+**Boundaries:**  
+- Expose inbound ports and use outbound ports.  
+- Never depend on adapter implementations directly.
+
+---
+
+## Ports
+
+### Inbound Ports
+
+**Responsibilities:**  
+- Define interfaces to drive application use cases (commands, queries).  
+- Specify system capabilities for external actors.
+
+**Must:**  
+- Be purely abstract, language- and technology-agnostic.  
+- Be declared in the application layer.
+
+**Must Not:**  
+- Leak technical details (e.g., HTTP, messaging) into definitions.  
+- Depend on adapter-specific data structures.
+
+**Boundaries:**  
+- Implemented only by inbound adapters.
+
+### Outbound Ports
+
+**Responsibilities:**  
+- Define interfaces for required external operations (persistence, messaging).  
+- Specify system needs from the outside world.
+
+**Must:**  
+- Be purely abstract and represent business needs, not technical mechanisms.  
+- Be declared in the application layer.
+
+**Must Not:**  
+- Match specific databases or external APIs.  
+- Include technical error handling or transport concerns.
+
+**Boundaries:**  
+- Implemented only by outbound adapters.
+
+---
+
+## Adapters
+
+### Inbound Adapters
+
+**Responsibilities:**  
+- Translate external requests into calls to inbound ports.  
+- Handle protocol-specific concerns (parsing, validation, authentication).
+
+**Must:**  
+- Implement inbound ports only.  
+- Depend on external protocols and frameworks.  
+- Validate inputs rigorously.
+
+**Must Not:**  
+- Contain business or workflow logic.  
+- Access domain or application internals directly.  
+- Skip validation or leak invalid data.
+
+**Boundaries:**  
+- Do not depend on other adapters or infrastructure details.
+
+### Outbound Adapters
+
+**Responsibilities:**  
+- Implement outbound ports to connect with infrastructure (databases, APIs, message brokers).  
+- Translate domain/application requests into external system interactions.
+
+**Must:**  
+- Implement outbound ports only.  
+- Handle errors properly and translate to port-level abstractions.  
+- Depend on external technologies and protocols.
+
+**Must Not:**  
+- Contain business or application logic.  
+- Know use case orchestration details.  
+- Leak external data structures into domain or application.  
+- Allow infrastructure failures to propagate as technical exceptions.
+
+**Boundaries:**  
+- Do not depend on other adapters, application, or domain internals.
+
+---
+
+## Boundaries & Allowed Dependencies
+
+- **Domain:** MUST have no dependencies.  
+- **Application:** MUST depend only on domain and port interfaces.  
+- **Ports:** MUST be pure interfaces; MUST NOT depend on adapters or infrastructure.  
+- **Adapters:** MUST depend on ports and external technologies ONLY; MUST NOT depend on domain or application internals.
+
+**Allowed Interaction Flow:**  
+Inbound adapters → inbound ports → application → domain → outbound ports → outbound adapters.
+
+**Prohibited Interactions:**  
+- Adapters MUST NOT call domain or application internals directly.  
+- Domain MUST NOT depend on application, ports, or adapters.  
+- Application MUST NOT depend on adapters or infrastructure.
+
+---
+
+## Decision Table
+
+| Concern/Responsibility        | Domain | Application | Ports | Adapters |
+|------------------------------|--------|-------------|-------|----------|
+| Business rules               | MUST   | MUST NOT    | MUST NOT | MUST NOT |
+| Use case orchestration       | MUST NOT | MUST     | MUST NOT | MUST NOT |
+| Interface definition         | MUST NOT | MUST      | MUST    | MUST NOT |
+| Protocol translation         | MUST NOT | MUST NOT  | MUST NOT | MUST    |
+| Infrastructure integration   | MUST NOT | MUST NOT  | MUST NOT | MUST    |
+| External communication       | MUST NOT | MUST NOT  | MUST NOT | MUST    |
+| Dependency on frameworks     | MUST NOT | MUST NOT  | MUST NOT | MUST    |
+| Statelessness               | MUST    | MUST       | MUST    | MUST    |
+
+---
+
+## Agent Directive
+
+1. **Respect component responsibilities:** Agents must assign tasks and logic according to component roles.  
+2. **Enforce dependency rules:** Agents must not create or allow prohibited dependencies.  
+3. **Use ports as boundaries:** Agents must communicate between layers strictly via ports.  
+4. **Avoid embedding logic in adapters:** Agents must keep adapters free of business and orchestration logic.  
+5. **Validate inputs at inbound adapters:** Agents must ensure all external data is validated before reaching application or domain.  
+6. **Maintain purity of domain:** Agents must prevent technical concerns from leaking into domain logic.  
+7. **Follow interaction flow:** Agents must route communication through the allowed path only.  
+8. **Ensure testability:** Agents must design components to be independently testable.  
+9. **Report violations:** Agents must flag any breach of these rules immediately.

--- a/cli/bundled/context/project_structure.md
+++ b/cli/bundled/context/project_structure.md
@@ -1,0 +1,143 @@
+# Hexagonal Architecture Project Structure
+
+This document defines the standard folder structure for Python backend services following Domain Driven Design and Hexagonal Architecture (Ports & Adapters) patterns.
+
+## Overview
+
+- Organize by hexagonal architecture layers with clear port placement
+- **Domain ports**: Repository interfaces and domain service ports in domain layer
+- **Primary ports**: (driving) define application use cases - belong in application layer
+- **Infrastructure secondary ports** (email, messaging, external APIs) - belong in application layer
+- **Secondary adapters**: Organize by technology for shared infrastructure and easier maintenance
+- **Technology-specific models**: Persistence models live within their respective technology adapters
+- **Configuration layer**: Cross-cutting concerns that wire all layers together
+- Domain and application layers should only depend on their respective port interfaces
+- Adapters layer contains all adapter implementations
+
+## Standard Structure
+
+```
+src/
+├── domain/
+│   ├── model/
+│   │   ├── user/
+│   │   │   ├── user.py              # Entity
+│   │   │   └── email.py             # Value Object
+│   │   └── order/
+│   ├── ports/                       # Domain Ports (Secondary)
+│   │   ├── user_repository.py       # Repository interface (domain concept)
+│   │   ├── order_repository.py
+│   │   ├── pricing_service_port.py  # Domain service interface
+│   │   ├── inventory_service_port.py
+│   │   └── domain_event_store_port.py  # Domain-specific event storage
+│   └── events/                      # Domain Events
+├── application/
+│   ├── ports/
+│   │   ├── primary/                 # Primary Ports (Use Cases)
+│   │   │   ├── create_user_port.py          # Primary Port
+│   │   │   ├── change_user_email_port.py    # Primary Port
+│   │   │   └── deactivate_user_port.py      # Primary Port
+│   │   └── secondary/               # Infrastructure Ports (Secondary)
+│   │       ├── email_notification_port.py   # Infrastructure service
+│   │       ├── event_publisher_port.py      # Infrastructure service
+│   │       └── payment_gateway_port.py      # Infrastructure service
+│   ├── use_cases/
+│   │   ├── create_user_use_case.py          # Use Case (Primary Port Implementation)
+│   │   ├── change_user_email_use_case.py    # Use Case (Primary Port Implementation)
+│   │   └── deactivate_user_use_case.py      # Use Case (Primary Port Implementation)
+│   ├── commands/
+│   ├── queries/
+│   └── handlers/
+├── adapters/
+│   ├── primary/
+│   │   ├── web/
+│   │   │   ├── user_controller.py       # Primary Adapter
+│   │   │   └── order_controller.py
+│   │   ├── cli/
+│   │   └── messaging/
+│   └── secondary/                       # Organized by Technology
+│       ├── sql/
+│       │   ├── models/                          # SQLAlchemy models
+│       │   │   ├── user_model.py
+│       │   │   └── order_model.py
+│       │   ├── base_sql_repository.py          # Shared base class
+│       │   ├── sql_connection_manager.py       # Shared connection handling
+│       │   ├── sql_user_repository.py          # Implements UserRepository
+│       │   ├── sql_order_repository.py         # Implements OrderRepository
+│       │   └── sql_domain_event_store.py       # Implements DomainEventStorePort
+│       ├── mongodb/
+│       │   ├── schemas/                         # MongoDB schemas
+│       │   │   ├── user_schema.py
+│       │   │   └── order_schema.py
+│       │   ├── mongo_connection.py             # Shared connection
+│       │   ├── mongo_user_repository.py        # Implements UserRepository
+│       │   └── mongo_order_repository.py       # Implements OrderRepository
+│       ├── http/
+│       │   ├── base_http_client.py             # Shared HTTP utilities
+│       │   ├── http_retry_policy.py            # Shared retry logic
+│       │   ├── http_pricing_service.py         # Implements PricingServicePort
+│       │   ├── http_payment_gateway.py         # Implements PaymentGatewayPort
+│       │   └── http_email_service.py           # Implements EmailNotificationPort
+│       ├── messaging/
+│       │   ├── rabbitmq_connection.py          # Shared connection
+│       │   ├── rabbitmq_event_publisher.py     # Implements EventPublisherPort
+│       │   └── rabbitmq_notification_sender.py # Implements NotificationPort
+│       └── redis/
+│           ├── redis_connection.py             # Shared connection
+│           ├── redis_cache_service.py          # Implements CacheServicePort
+│           └── redis_session_store.py          # Implements SessionStorePort
+└── configuration/                           # Cross-cutting Configuration Layer
+    ├── di_container.py                      # Dependency injection container
+    ├── database_config.py                  # Database configuration
+    ├── app_settings.py                     # Application settings
+    └── environment_config.py               # Environment-specific config
+```
+
+## Layer Descriptions
+
+### Domain Layer (`src/domain/`)
+- **model/**: Contains Entities, Value Objects, and Aggregates organized by domain concept
+- **ports/**: Repository interfaces and domain service ports (secondary ports from domain perspective)
+- **events/**: Domain event definitions
+
+### Application Layer (`src/application/`)
+- **ports/primary/**: Primary ports defining use case interfaces
+- **ports/secondary/**: Infrastructure service ports (email, messaging, external APIs)
+- **use_cases/**: Use case implementations that implement primary ports
+- **commands/**: Command objects for write operations
+- **queries/**: Query objects for read operations
+- **handlers/**: Event handlers and other cross-cutting handlers
+
+### Adapters Layer (`src/adapters/`)
+- **primary/**: Entry point adapters (web controllers, CLI, message consumers)
+- **secondary/**: Organized by technology (sql, mongodb, http, messaging, redis, etc.)
+  - Each technology folder contains its own models/schemas and adapter implementations
+  - Shared infrastructure code (connections, base classes, utilities) lives within technology folders
+
+### Configuration Layer (`src/configuration/`)
+- Dependency injection container
+- Database and infrastructure configuration
+- Environment-specific settings
+- Wires all layers together at application startup
+
+## Key Principles
+
+1. **Port Placement**:
+   - Domain ports (repositories, domain services) → `domain/ports/`
+   - Primary ports (use case interfaces) → `application/ports/primary/`
+   - Infrastructure ports (external services) → `application/ports/secondary/`
+
+2. **Adapter Organization**:
+   - Primary adapters → `infrastructure/adapters/primary/` (organized by adapter type)
+   - Secondary adapters → `infrastructure/adapters/secondary/` (organized by technology)
+
+3. **Technology-Specific Models**:
+   - SQLAlchemy models → `infrastructure/adapters/secondary/sql/models/`
+   - MongoDB schemas → `infrastructure/adapters/secondary/mongodb/schemas/`
+   - Keep persistence models close to their adapter implementations
+
+4. **Dependency Direction**:
+   - Domain layer → No external dependencies
+   - Application layer → Depends on domain ports only
+   - Infrastructure layer → Implements all ports, depends on external frameworks
+   - Configuration layer → Depends on all layers to wire them together

--- a/cli/bundled/rules.md
+++ b/cli/bundled/rules.md
@@ -1,0 +1,1209 @@
+# Domain Driven Design with Ports & Adapters Rules for Python Implementation
+
+## Core Domain Model Rules
+
+### 1. Entity Rules
+- Entities MUST have a unique identity that persists throughout their lifecycle
+- Use `@dataclass(eq=False)` for mutable entities — the `eq=False` prevents Python from generating `__eq__` and `__hash__` based on all fields, which would override the identity-based equality that entities require
+- Identity should be immutable once set (use `field(init=False)` for auto-generated IDs)
+- Implement `__eq__` and `__hash__` based solely on identity, not attributes
+- Entities MUST contain business logic as methods, not just data
+- Avoid anemic domain models - entities should have behavior
+
+```python
+@dataclass(eq=False)
+class User:
+    id: UserId = field(init=False)
+    email: Email
+    name: str
+    
+    def __post_init__(self):
+        if not hasattr(self, 'id'):
+            self.id = UserId.generate()
+    
+    def change_email(self, new_email: Email) -> None:
+        # Business logic here
+        self.email = new_email
+```
+
+### 2. Value Object Rules
+- Value objects MUST be immutable - use `@dataclass(frozen=True)`
+- Equality is based on ALL attributes, not identity
+- Should be small, focused, and represent a concept from the domain
+- Include validation in `__post_init__` method
+- Should have meaningful methods that operate on the value
+
+```python
+@dataclass(frozen=True)
+class Email:
+    value: str
+    
+    def __post_init__(self):
+        if '@' not in self.value:
+            raise ValueError("Invalid email format")
+    
+    @property
+    def domain(self) -> str:
+        return self.value.split('@')[1]
+```
+
+### 3. Aggregate Rules
+- Aggregates MUST have a single Aggregate Root (an Entity)
+- Only the Aggregate Root should be directly accessible from outside
+- Internal entities within an aggregate should be accessed through the root
+- Aggregate boundaries should align with transaction boundaries
+- Use factory methods on aggregates for complex creation logic
+- Aggregates should be small and focused
+- Cross-child invariants (rules that span multiple child entities within an aggregate) MUST be enforced by the aggregate root's methods, not by repositories or use cases. If two things must be consistent within the same transaction, they belong in the same aggregate.
+
+**Aggregate persistence rules:**
+- Child entities within an aggregate (e.g., line items in an order, assignments in a staff record) are persisted in **separate database tables** for normalization and queryability
+- The aggregate root's **single repository** loads and saves all child entities in one transaction — no separate repositories for child entities
+- The aggregate is a **domain concept**, not a persistence concept. How it is stored is an infrastructure detail
+- At small volumes (< 100 child entities), eagerly load the full aggregate on every operation. Consider lazy loading only when child collections grow to hundreds or thousands of items.
+
+```python
+@dataclass(eq=False)
+class Order:  # Aggregate Root
+    id: OrderId
+    customer_id: CustomerId
+    _line_items: list[OrderLineItem] = field(default_factory=list, init=False)
+
+    def add_line_item(self, product_id: ProductId, quantity: int) -> None:
+        # Business rules and validation
+        line_item = OrderLineItem(product_id, quantity)
+        self._line_items.append(line_item)
+
+    @property
+    def line_items(self) -> tuple[OrderLineItem, ...]:
+        return tuple(self._line_items)  # Return immutable view
+```
+
+### 4. Domain Service Rules
+- Create domain services ONLY when business logic doesn't naturally fit in entities or value objects
+- Domain services should be stateless
+- Use dependency injection for external dependencies
+- Should operate on domain objects, not primitives
+- Name services with domain language (not technical terms)
+
+```python
+class PricingService:
+    def __init__(self, discount_repository: DiscountRepository):
+        self._discount_repository = discount_repository
+    
+    def calculate_order_total(self, order: Order, customer: Customer) -> Money:
+        # Complex pricing logic that spans multiple aggregates
+        pass
+```
+
+## Repository Pattern Rules
+
+### 5. Repository Interface Rules
+- Define repository interfaces in the domain layer using ABC - they represent domain concepts
+- Repositories should work with Aggregate Roots only
+- Use domain-specific query methods, not generic CRUD
+- Return domain objects, never DTOs or database models
+- Should throw domain exceptions, not infrastructure exceptions
+- Query methods (`find_by_id`, `find_by_email`, etc.) return `None` when the entity is not found — absence is a normal query outcome, not an exception. The **use case** decides whether absence is an error and raises the appropriate domain exception (e.g., `UserNotFoundError`). Repositories never raise "not found" exceptions.
+
+```python
+# Domain Layer - domain/repositories/user_repository.py
+from abc import ABC, abstractmethod
+
+class UserRepository(ABC):
+    @abstractmethod
+    def find_by_email(self, email: Email) -> Optional[User]:
+        pass
+    
+    @abstractmethod
+    def save(self, user: User) -> None:
+        pass
+    
+    @abstractmethod
+    def find_active_users_in_department(self, department_id: DepartmentId) -> list[User]:
+        pass
+    
+    @abstractmethod
+    def find_by_id(self, user_id: UserId) -> Optional[User]:
+        pass
+```
+
+### 6. Repository Implementation Rules
+- Implement repositories in the infrastructure layer
+- Use the Unit of Work pattern for transaction management
+- Map between domain objects and persistence models
+- Handle optimistic concurrency using version fields
+- Repository should not contain business logic
+
+## Domain Event Rules
+
+### 7. Domain Event Rules
+- Domain events should be immutable value objects
+- Events should represent something that happened in the past (use past tense)
+- Events should contain all necessary data to handle the event
+- Use `@dataclass(frozen=True)` for events
+- Events should be raised by aggregates, not external code
+- Domain event names MUST use ubiquitous language from the business domain only — no technology-specific or external-system terms (e.g., no vendor names like "Auth0", "Clerk", "Stripe"; no infrastructure terms like "SQL", "SQS", "Lambda", "DynamoDB"). The event name should be meaningful to a domain expert who knows nothing about the implementation. For example: `UserCreated` is correct, `Auth0UserCreated` is wrong; `PaymentProcessed` is correct, `StripePaymentProcessed` is wrong.
+- **Inheritance caveat**: When using a `DomainEvent` base class with a default field (e.g., `occurred_at: datetime = field(default_factory=...)`), all subclass fields MUST also have defaults. Python dataclass inheritance does not allow non-default fields to follow default fields from a parent class. Use empty-value defaults (e.g., `user_id: str = ""`) or make the base class field non-default and always pass it explicitly.
+
+```python
+@dataclass(frozen=True)
+class DomainEvent:
+    """Base class — has a default field."""
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+@dataclass(frozen=True)
+class UserEmailChanged(DomainEvent):
+    """Subclass fields MUST have defaults because parent has occurred_at with a default."""
+    user_id: str = ""
+    old_email: str = ""
+    new_email: str = ""
+```
+
+### 8. Event Handling Rules
+- Domain event handlers should be in the application layer
+- Handlers should be idempotent
+- Use dependency injection for handler dependencies
+- Handlers should not directly modify other aggregates
+- Consider eventual consistency for cross-aggregate operations
+
+## Application Service Rules
+
+### 9. Use Case Rules
+- Use cases represent single business operations that the application can perform
+- Each use case should handle exactly one business workflow
+- Use cases orchestrate domain objects but contain no business logic
+- Should be stateless and focused on a single responsibility
+- Handle cross-cutting concerns (transactions, events, etc.)
+- Use cases return **domain objects** (entities, aggregates). The primary adapter (controller) is responsible for mapping domain objects to external representations (e.g., Pydantic response models, JSON). This follows hexagonal architecture — adapters are the translation layer, not use cases. (Note: Clean Architecture prescribes response DTOs from use cases, but in hexagonal architecture the adapter handles this translation.)
+- Name use cases after business operations using domain language
+
+```python
+class CreateUserUseCase:
+    def __init__(
+        self, 
+        user_repository: UserRepository,
+        unit_of_work: UnitOfWork,
+        event_publisher: EventPublisher
+    ):
+        self._user_repository = user_repository
+        self._unit_of_work = unit_of_work
+        self._event_publisher = event_publisher
+    
+    def execute(self, command: CreateUserCommand) -> CreateUserResponse:
+        with self._unit_of_work:
+            # Orchestration logic only
+            email = Email(command.email)
+            user = User.create(email, command.name)
+            self._user_repository.save(user)
+            self._event_publisher.publish(UserCreated(user.id, email))
+            return CreateUserResponse(user.id.value)
+
+class ChangeUserEmailUseCase:
+    def __init__(self, user_repository: UserRepository, unit_of_work: UnitOfWork):
+        self._user_repository = user_repository
+        self._unit_of_work = unit_of_work
+    
+    def execute(self, command: ChangeEmailCommand) -> None:
+        with self._unit_of_work:
+            user = self._user_repository.find_by_id(command.user_id)
+            if not user:
+                raise UserNotFoundError(command.user_id)
+            user.change_email(Email(command.new_email))
+            self._user_repository.save(user)
+```
+
+## Ports & Adapters (Hexagonal Architecture) Rules
+
+### 10. Port Definition Rules
+- Ports define interfaces between layers and external systems
+- **Primary ports** (driving) define application use cases - belong in application layer
+- **Domain-driven secondary ports** (repositories, domain services) - belong in domain layer  
+- **Infrastructure secondary ports** (email, messaging, external APIs) - belong in application layer
+- Port interfaces should use domain language, not technical terms
+- Ports should be focused and follow Single Responsibility Principle
+
+```python
+# Primary Ports (Application Layer) - application/ports/primary/
+class CreateUserPort(ABC):
+    @abstractmethod
+    def execute(self, command: CreateUserCommand) -> CreateUserResponse:
+        pass
+
+class ChangeUserEmailPort(ABC):
+    @abstractmethod
+    def execute(self, command: ChangeEmailCommand) -> None:
+        pass
+
+# Domain-Driven Secondary Ports (Domain Layer) - domain/repositories/
+class UserRepository(ABC):  # Already shown in rule 5
+    @abstractmethod
+    def find_by_email(self, email: Email) -> Optional[User]:
+        pass
+
+# Domain Services (Domain Layer) - domain/services/
+class PricingServicePort(ABC):
+    @abstractmethod
+    def calculate_product_price(self, product: Product, customer: Customer) -> Money:
+        pass
+
+# Infrastructure Secondary Ports (Application Layer) - application/ports/secondary/
+class EmailNotificationPort(ABC):
+    @abstractmethod
+    def send_welcome_email(self, user_email: Email, user_name: str) -> None:
+        pass
+    
+    @abstractmethod
+    def send_email_change_notification(self, old_email: Email, new_email: Email) -> None:
+        pass
+
+class EventPublisherPort(ABC):
+    @abstractmethod
+    def publish(self, event: DomainEvent) -> None:
+        pass
+```
+
+### 11. Primary Adapter Rules
+- Primary adapters are the entry points (web controllers, CLI, message consumers)
+- Should translate external requests to domain commands/queries
+- Must not contain business logic - only translation and validation
+- Should handle framework-specific concerns (HTTP status codes, serialization)
+- Should be thin and delegate to use cases through primary ports
+
+```python
+# FastAPI Controller (Primary Adapter)
+from fastapi import APIRouter, HTTPException, Depends, status
+from pydantic import BaseModel
+
+class CreateUserRequest(BaseModel):
+    email: str
+    name: str
+
+class ChangeEmailRequest(BaseModel):
+    email: str
+
+class CreateUserResponse(BaseModel):
+    user_id: str
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+@router.post("/", status_code=status.HTTP_201_CREATED, response_model=CreateUserResponse)
+async def create_user(
+    request: CreateUserRequest,
+    use_case: CreateUserPort = Depends()
+) -> CreateUserResponse:
+    try:
+        command = CreateUserCommand(
+            email=request.email,
+            name=request.name
+        )
+        response = use_case.execute(command)
+        return CreateUserResponse(user_id=response.user_id)
+    except InvalidEmailError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid email: {str(e)}")
+    except UserAlreadyExistsError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except DomainException as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@router.patch("/{user_id}/email", status_code=status.HTTP_204_NO_CONTENT)
+async def change_user_email(
+    user_id: str,
+    request: ChangeEmailRequest,
+    use_case: ChangeUserEmailPort = Depends()
+) -> None:
+    try:
+        command = ChangeEmailCommand(
+            user_id=UserId(user_id),
+            new_email=request.email
+        )
+        use_case.execute(command)
+    except UserNotFoundError:
+        raise HTTPException(status_code=404, detail="User not found")
+    except InvalidEmailError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid email: {str(e)}")
+    except DomainException as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@router.get("/{user_id}", response_model=GetUserResponse)
+async def get_user(
+    user_id: str,
+    use_case: GetUserPort = Depends()
+) -> GetUserResponse:
+    try:
+        query = GetUserQuery(user_id=UserId(user_id))
+        response = use_case.execute(query)
+        return GetUserResponse(
+            user_id=response.user_id,
+            email=response.email,
+            name=response.name
+        )
+    except UserNotFoundError:
+        raise HTTPException(status_code=404, detail="User not found")
+    except DomainException as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def deactivate_user(
+    user_id: str,
+    use_case: DeactivateUserPort = Depends()
+) -> None:
+    try:
+        command = DeactivateUserCommand(user_id=UserId(user_id))
+        use_case.execute(command)
+    except UserNotFoundError:
+        raise HTTPException(status_code=404, detail="User not found")
+    except UserAlreadyDeactivatedError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except DomainException as e:
+        raise HTTPException(status_code=400, detail=str(e))
+```
+
+### 12. Secondary Adapter Rules
+- Secondary adapters implement secondary ports defined in domain/application layers
+- Organize secondary adapters by technology for shared infrastructure and easier maintenance
+- Should handle all external system complexities (database mapping, API calls, etc.)
+- Must translate between domain objects and external representations
+- Should not expose external system details to the domain
+- Include error handling and retry logic when appropriate
+- Keep technology-specific models/schemas within their adapter implementations
+
+```python
+# SQL Database Adapter - infrastructure/adapters/secondary/sql/sql_user_repository.py
+class SqlUserRepository(UserRepository):
+    def __init__(self, session: Session):
+        self._session = session
+    
+    def save(self, user: User) -> None:
+        user_model = UserModel(
+            id=user.id.value,
+            email=user.email.value,
+            name=user.name,
+            version=user.version
+        )
+        self._session.merge(user_model)
+    
+    def find_by_email(self, email: Email) -> Optional[User]:
+        model = self._session.query(UserModel).filter_by(email=email.value).first()
+        return self._to_domain(model) if model else None
+    
+    def _to_domain(self, model: UserModel) -> User:
+        return User(
+            id=UserId(model.id),
+            email=Email(model.email),
+            name=model.name
+        )
+
+# HTTP External Service Adapter - infrastructure/adapters/secondary/http/http_email_service.py
+class HttpEmailNotificationAdapter(EmailNotificationPort):
+    def __init__(self, http_client: HTTPClient, api_config: EmailAPIConfig):
+        self._http_client = http_client
+        self._api_config = api_config
+    
+    def send_welcome_email(self, user_email: Email, user_name: str) -> None:
+        payload = {
+            'to': user_email.value,
+            'template': 'welcome',
+            'variables': {'name': user_name}
+        }
+        response = self._http_client.post(
+            f"{self._api_config.base_url}/send",
+            json=payload,
+            headers={'Authorization': f'Bearer {self._api_config.api_key}'}
+        )
+        if response.status_code != 200:
+            raise EmailDeliveryError(f"Failed to send email: {response.text}")
+```
+
+### 13. Adapter Configuration Rules
+- Use Dependency Injection container to wire adapters to ports
+- Configuration should happen at application startup in a composition root
+- Adapters should be configurable through environment variables or config files
+- Use factory patterns for complex adapter creation
+- Keep configuration separate from business logic
+- Configuration layer manages all technology-specific adapter instantiation
+
+```python
+# Configuration Layer - configuration/di_container.py
+class DIContainer:
+    def __init__(self, config: Config):
+        self._config = config
+        self._sql_session = self._create_sql_session()
+        self._mongo_client = self._create_mongo_client()
+        self._http_client = self._create_http_client()
+    
+    # Domain port implementations (SQL technology)
+    def sql_user_repository(self) -> UserRepository:
+        return SqlUserRepository(self._sql_session)
+    
+    # Domain port implementations (MongoDB technology)  
+    def mongo_user_repository(self) -> UserRepository:
+        return MongoUserRepository(self._mongo_client)
+    
+    # Infrastructure port implementations
+    def http_email_notification_service(self) -> EmailNotificationPort:
+        return HttpEmailNotificationAdapter(
+            self._http_client,
+            self._config.email_api_config
+        )
+    
+    def rabbitmq_event_publisher(self) -> EventPublisherPort:
+        return RabbitMqEventPublisher(
+            connection=self._create_rabbitmq_connection()
+        )
+    
+    # Use case implementations
+    def create_user_use_case(self) -> CreateUserPort:
+        return CreateUserUseCase(
+            user_repository=self.sql_user_repository(),  # Choose technology
+            email_service=self.http_email_notification_service(),
+            event_publisher=self.rabbitmq_event_publisher(),
+            unit_of_work=UnitOfWork(self._sql_session)
+        )
+```
+
+## Integrated Project Structure Rules
+
+## Integrated Project Structure Rules
+
+### 14. Hexagonal Package Structure Rules
+- Organize by hexagonal architecture layers with clear port placement
+- **Domain ports**: Repository interfaces and domain service ports in domain layer
+- **Application ports**: Primary ports (use cases) and infrastructure service ports in application layer
+- **Secondary adapters**: Organize by technology for shared infrastructure and easier maintenance
+- **Technology-specific models**: Persistence models live within their respective technology adapters
+- **Configuration layer**: Cross-cutting concerns that wire all layers together
+- Domain and application layers should only depend on their respective port interfaces
+- Infrastructure layer contains all adapter implementations
+- **One class per file** — each entity, value object, port, use case, and adapter should be in its own file. This makes classes easy to find and prevents large files.
+- **No implementation code in `__init__.py`** — `__init__.py` files should be empty or contain only re-exports. Public interfaces, services, and classes must be in dedicated files.
+
+**Domain layer organization** — two valid approaches (pick one and be consistent within a module):
+
+**Option A: Organize by subdomain** (group related entities and value objects together):
+```
+domain/
+├── model/
+│   ├── user/
+│   │   ├── user.py              # Entity
+│   │   └── email.py             # Value Object
+│   └── order/
+```
+
+**Option B: Organize by type** (group all entities together, all value objects together):
+```
+domain/
+├── entities/
+│   ├── user.py
+│   └── order.py
+├── value_objects/
+│   ├── email.py
+│   ├── user_id.py
+│   └── order_id.py
+```
+
+Both approaches MUST keep ports, events, and exceptions in their own directories regardless:
+
+```
+src/
+├── domain/
+│   ├── ... (entities and value objects per chosen option above)
+│   ├── ports/                       # Domain Ports (Secondary)
+│   │   ├── user_repository.py       # Repository interface (domain concept)
+│   │   ├── order_repository.py
+│   │   ├── pricing_service_port.py  # Domain service interface
+│   │   ├── inventory_service_port.py
+│   │   └── domain_event_store_port.py  # Domain-specific event storage
+│   └── events/                      # Domain Events
+├── application/
+│   ├── ports/
+│   │   ├── primary/                 # Primary Ports (Use Cases)
+│   │   │   ├── create_user_port.py          # Primary Port
+│   │   │   ├── change_user_email_port.py    # Primary Port
+│   │   │   └── deactivate_user_port.py      # Primary Port
+│   │   └── secondary/               # Infrastructure Ports (Secondary)
+│   │       ├── email_notification_port.py   # Infrastructure service
+│   │       ├── event_publisher_port.py      # Infrastructure service
+│   │       └── payment_gateway_port.py      # Infrastructure service
+│   ├── use_cases/
+│   │   ├── create_user_use_case.py          # Use Case (Primary Port Implementation)
+│   │   ├── change_user_email_use_case.py    # Use Case (Primary Port Implementation)
+│   │   └── deactivate_user_use_case.py      # Use Case (Primary Port Implementation)
+│   ├── commands/
+│   ├── queries/
+│   └── handlers/
+├── infrastructure/
+│   └── adapters/
+│       ├── primary/
+│       │   ├── web/
+│       │   │   ├── user_controller.py       # Primary Adapter
+│       │   │   └── order_controller.py
+│       │   ├── cli/
+│       │   └── messaging/
+│       └── secondary/                       # Organized by Technology
+│           ├── sql/
+│           │   ├── models/                          # SQLAlchemy models
+│           │   │   ├── user_model.py
+│           │   │   └── order_model.py
+│           │   ├── base_sql_repository.py          # Shared base class
+│           │   ├── sql_connection_manager.py       # Shared connection handling
+│           │   ├── sql_user_repository.py          # Implements UserRepository
+│           │   ├── sql_order_repository.py         # Implements OrderRepository
+│           │   └── sql_domain_event_store.py       # Implements DomainEventStorePort
+│           ├── mongodb/
+│           │   ├── schemas/                         # MongoDB schemas
+│           │   │   ├── user_schema.py
+│           │   │   └── order_schema.py
+│           │   ├── mongo_connection.py             # Shared connection
+│           │   ├── mongo_user_repository.py        # Implements UserRepository
+│           │   └── mongo_order_repository.py       # Implements OrderRepository
+│           ├── http/
+│           │   ├── base_http_client.py             # Shared HTTP utilities
+│           │   ├── http_retry_policy.py            # Shared retry logic
+│           │   ├── http_pricing_service.py         # Implements PricingServicePort
+│           │   ├── http_payment_gateway.py         # Implements PaymentGatewayPort
+│           │   └── http_email_service.py           # Implements EmailNotificationPort
+│           ├── messaging/
+│           │   ├── rabbitmq_connection.py          # Shared connection
+│           │   ├── rabbitmq_event_publisher.py     # Implements EventPublisherPort
+│           │   └── rabbitmq_notification_sender.py # Implements NotificationPort
+│           └── redis/
+│               ├── redis_connection.py             # Shared connection
+│               ├── redis_cache_service.py          # Implements CacheServicePort
+│               └── redis_session_store.py          # Implements SessionStorePort
+└── configuration/                           # Cross-cutting Configuration Layer
+    ├── di_container.py                      # Dependency injection container
+    ├── database_config.py                  # Database configuration
+    ├── app_settings.py                     # Application settings
+    └── environment_config.py               # Environment-specific config
+```
+
+### 15. Integration Flow Rules
+- Primary adapters call primary ports (use cases)
+- Use cases orchestrate domain objects and use secondary ports for external systems
+- Secondary adapters implement secondary ports and handle external complexities
+- Domain objects should never directly depend on adapters
+- Use events for loose coupling between bounded contexts
+
+```python
+# Flow Example: Web Request → Controller → Use Case → Repository
+class UserController:  # Primary Adapter
+    def create_user(self, request) -> Response:
+        command = CreateUserCommand(request.email, request.name)
+        response = self._create_user_use_case.execute(command)  # → Primary Port
+        return Response(201, {'user_id': response.user_id})
+
+class CreateUserUseCase(CreateUserPort):  # Primary Port Implementation
+    def execute(self, command: CreateUserCommand) -> CreateUserResponse:
+        email = Email(command.email)
+        user = User.create(email, command.name)
+        self._user_repository.save(user)  # → Secondary Port
+        self._email_service.send_welcome_email(email, command.name)  # → Secondary Port
+        return CreateUserResponse(user.id.value)
+```
+
+## Synergy Rules for DDD + Ports & Adapters
+
+### 16. Repository as Secondary Port Rules
+- Repository interfaces are domain ports (interfaces in domain layer)
+- Repository implementations are secondary adapters (in infrastructure layer)
+- Repositories should work with Aggregate Roots and use domain language
+- Repository adapters handle ORM mapping and database specifics
+- Keep repository interfaces focused on domain needs, not database capabilities
+
+### 17. Use Case as Primary Port Implementation Rules
+- Use cases implement primary ports and orchestrate domain objects
+- They use both domain ports (repositories) and infrastructure ports (email, messaging)
+- Should not contain business logic - delegate to domain objects
+- Handle cross-cutting concerns like transactions and event publishing
+- Serve as the application's use case boundary
+- Each use case should represent exactly one business workflow
+
+```python
+class CreateUserUseCase(CreateUserPort):
+    def __init__(
+        self,
+        user_repository: UserRepository,  # Domain port
+        email_service: EmailNotificationPort,  # Infrastructure port
+        event_publisher: EventPublisherPort,  # Infrastructure port
+        unit_of_work: UnitOfWork
+    ):
+        self._user_repository = user_repository
+        self._email_service = email_service
+        self._event_publisher = event_publisher
+        self._unit_of_work = unit_of_work
+    
+    def execute(self, command: CreateUserCommand) -> CreateUserResponse:
+        with self._unit_of_work:
+            email = Email(command.email)
+            user = User.create(email, command.name)
+            self._user_repository.save(user)  # Domain port
+            self._email_service.send_welcome_email(email, command.name)  # Infrastructure port
+            self._event_publisher.publish(UserCreated(user.id, email))  # Infrastructure port
+            return CreateUserResponse(user.id.value)
+```
+
+### 18. Event Integration Rules
+- Domain events should be published through infrastructure ports
+- Event handlers can be implemented as separate use cases
+- Use event-driven architecture for cross-bounded context communication
+- Events enable loose coupling between adapters and domain logic
+- Consider eventual consistency for distributed operations
+
+```python
+# Event Publishing through Infrastructure Port
+class EventPublisherPort(ABC):  # Application layer
+    @abstractmethod
+    def publish(self, event: DomainEvent) -> None:
+        pass
+
+class CreateUserUseCase(CreateUserPort):
+    def __init__(
+        self, 
+        user_repo: UserRepository,  # Domain port
+        event_publisher: EventPublisherPort  # Infrastructure port
+    ):
+        self._user_repo = user_repo
+        self._event_publisher = event_publisher
+    
+    def execute(self, command: CreateUserCommand) -> CreateUserResponse:
+        user = User.create(Email(command.email), command.name)
+        self._user_repo.save(user)  # Domain port
+        self._event_publisher.publish(UserCreated(user.id, user.email))  # Infrastructure port
+        return CreateUserResponse(user.id.value)
+
+# Event Handler as Use Case
+class SendWelcomeEmailUseCase:
+    def __init__(self, email_service: EmailNotificationPort):  # Infrastructure port
+        self._email_service = email_service
+    
+    def handle(self, event: UserCreated) -> None:
+        self._email_service.send_welcome_email(event.email, event.name)
+```
+
+### 19. Cross-Cutting Concern Rules
+- Handle infrastructure concerns (logging, metrics, caching) in adapters
+- Use decorators or middleware patterns for cross-cutting concerns
+- Keep domain objects free from infrastructure dependencies
+- Implement concerns like retries, circuit breakers in secondary adapters
+- Use aspect-oriented patterns at the adapter boundaries
+
+```python
+# Decorator for logging in adapters
+def logged_repository(func):
+    def wrapper(*args, **kwargs):
+        logger.info(f"Repository operation: {func.__name__}")
+        try:
+            result = func(*args, **kwargs)
+            logger.info(f"Operation successful: {func.__name__}")
+            return result
+        except Exception as e:
+            logger.error(f"Operation failed: {func.__name__}, error: {e}")
+            raise
+    return wrapper
+
+class SqlUserRepository(UserRepository):
+    @logged_repository
+    def save(self, user: User) -> None:
+        # Implementation
+        pass
+```
+
+## Cross-Bounded Context Communication Rules
+
+### 20. In-Process Cross-Context Communication (Modular Monolith)
+
+When one bounded context module needs data from another module in the same monolith:
+
+- The consuming module defines its own **port** (ABC) in its domain layer describing what it needs
+- The providing module exposes a **public query service** as a dedicated file — the only thing other modules may import
+- An **adapter** in the consuming module's infrastructure layer wraps the query service behind the port
+- The consuming module's domain and application layers MUST NOT import the providing module's internal code (entities, repositories, value objects)
+- This enables extraction to microservices later — swap the in-process adapter for an HTTP adapter with zero domain changes
+
+```python
+# Providing module exposes a public query service
+class InventoryQueryService:
+    def check_availability(self, product_id: str, quantity: int) -> bool: ...
+
+# Consuming module defines its own port
+class InventoryPort(ABC):
+    @abstractmethod
+    def check_availability(self, product_id: str, quantity: int) -> bool: ...
+
+# Consuming module's adapter wraps the query service
+class InProcessInventoryAdapter(InventoryPort):
+    def __init__(self, service: InventoryQueryService):
+        self._service = service
+
+    def check_availability(self, product_id: str, quantity: int) -> bool:
+        return self._service.check_availability(product_id, quantity)
+```
+
+### 21. Cross-Service Communication (Different Processes)
+
+When a bounded context needs to call an external service or a context running as a separate service:
+
+- The consuming module defines a **port** (ABC) in its domain layer
+- An **HTTP adapter** in infrastructure implements the port using an HTTP client
+- Only the bounded context that **owns** an external system should talk to it directly — other modules call that context's API through their own port + adapter
+- Service-to-service authentication should use dedicated service account credentials, not user tokens
+- The adapter maps HTTP errors to domain or adapter exceptions — the domain layer never sees HTTP status codes
+
+## Validation and Error Handling Rules
+- Test domain logic in isolation without any adapters
+- Test primary adapters by mocking primary ports
+- Test secondary adapters by mocking external dependencies
+- Use in-memory implementations of secondary ports for integration tests
+- Test the full flow from primary adapter to secondary adapter for end-to-end tests
+
+```python
+# Testing with port isolation
+class TestUserManagementService:
+    def test_create_user_success(self):
+        # Arrange
+        mock_repo = Mock(spec=UserRepository)
+        mock_events = Mock(spec=EventPublisherPort)
+        service = UserManagementService(mock_repo, mock_events)
+        
+        # Act
+        result = service.create_user(CreateUserCommand("test@example.com", "John"))
+        
+        # Assert
+        mock_repo.save.assert_called_once()
+        mock_events.publish.assert_called_once()
+        assert isinstance(result.user_id, str)
+
+# In-memory adapter for testing
+class InMemoryUserRepository(UserRepository):
+    def __init__(self):
+        self._users: dict[UserId, User] = {}
+    
+    def save(self, user: User) -> None:
+        self._users[user.id] = user
+    
+    def find_by_email(self, email: Email) -> Optional[User]:
+        return next((u for u in self._users.values() if u.email == email), None)
+```
+
+### 22. Validation and Error Handling Rules
+- Domain validation should happen in domain objects (entities, value objects)
+- Validation should be explicit and fail fast
+- Input validation in application services should be minimal
+- Use factory methods for complex validation scenarios
+- Use **two exception hierarchies** defined in the shared kernel:
+  - `DomainException` — raised by entities, value objects, and use cases for business rule violations (e.g., invalid email, entity not found, constraint violated)
+  - `AdapterException` — raised by infrastructure adapters when external systems fail (e.g., database unreachable, HTTP call failed). Adapters MUST wrap infrastructure-specific errors (e.g., `asyncpg.PostgresError`) in an `AdapterException` — the domain layer should never see infrastructure error types.
+- Primary adapters (controllers) should catch both hierarchies and map to appropriate responses (e.g., `DomainException` → 400/404/409, `AdapterException` → 502)
+
+```python
+class DomainException(Exception):
+    """Base for all domain/business rule violations."""
+    pass
+
+class AdapterException(Exception):
+    """Base for all infrastructure/adapter failures."""
+    pass
+
+class InvalidEmailError(DomainException):
+    pass
+
+class PersistenceError(AdapterException):
+    pass
+
+@dataclass(frozen=True)
+class Email:
+    value: str
+
+    def __post_init__(self):
+        if not self._is_valid_email(self.value):
+            raise InvalidEmailError(f"Invalid email: {self.value}")
+```
+
+### 23. Naming Convention Rules
+- Use domain language (Ubiquitous Language) for all class and method names
+- Avoid technical terms in domain layer (no "Manager", "Helper", "Util")  
+- Use intention-revealing names for methods
+- Value objects should be named after the concept they represent
+- Repository methods should reflect business queries
+- **Port Naming**: End primary ports with "Port", secondary ports with "Port"
+- **Adapter Naming**: Include the technology/framework in secondary adapter names
+- **Clear Port vs Adapter distinction**: Ports define interfaces, Adapters implement them
+
+```python
+# Good port names
+class UserManagementPort(ABC): pass           # Primary port
+class EmailNotificationPort(ABC): pass       # Secondary port
+class PaymentProcessingPort(ABC): pass       # Secondary port
+
+# Good adapter names  
+class RestUserController:                    # Primary adapter (REST)
+class GraphQLUserController:                 # Primary adapter (GraphQL)
+class SqlUserRepository(UserRepository):     # Secondary adapter (SQL)
+class MongoUserRepository(UserRepository):   # Secondary adapter (MongoDB)
+class SmtpEmailAdapter(EmailNotificationPort): # Secondary adapter (SMTP)
+class SendGridEmailAdapter(EmailNotificationPort): # Secondary adapter (SendGrid)
+```
+
+### 23. Dependency Rules
+- Domain layer should have no external dependencies except standard library
+- Application layer can depend on domain but should use dependency inversion for external concerns
+- Infrastructure layer implements all external dependencies through adapters
+- **Domain Port Dependencies**: Domain objects can depend on domain ports (repositories, domain services)
+- **Infrastructure Port Dependencies**: Use cases depend on infrastructure ports for external concerns
+- **Port Placement**: Domain ports in domain layer, infrastructure ports in application layer
+- **Inversion of Control**: Use DI container to wire adapters to ports at startup
+- Use dependency inversion - depend on abstractions, not concretions
+- Inject dependencies through constructors
+- Use factory pattern for complex object creation
+
+```python
+# Domain layer - can depend on domain ports
+class User:  # Domain entity
+    def __init__(self, id: UserId, email: Email, name: str):
+        self.id = id
+        self.email = email
+        self.name = name
+    
+    def change_email(self, new_email: Email) -> None:
+        # Business logic here
+        self.email = new_email
+
+class UserDomainService:  # Domain service
+    def __init__(self, user_repo: UserRepository):  # Domain port dependency
+        self._user_repo = user_repo
+    
+    def is_email_unique(self, email: Email) -> bool:
+        existing_user = self._user_repo.find_by_email(email)
+        return existing_user is None
+
+# Application layer - depends on domain + infrastructure ports
+class CreateUserUseCase(CreateUserPort):
+    def __init__(
+        self, 
+        user_repo: UserRepository,  # Domain port
+        user_domain_service: UserDomainService,  # Domain service
+        email_service: EmailNotificationPort,  # Infrastructure port
+        event_publisher: EventPublisherPort  # Infrastructure port
+    ):
+        self._user_repo = user_repo
+        self._user_domain_service = user_domain_service
+        self._email_service = email_service
+        self._event_publisher = event_publisher
+
+# Infrastructure layer - implements ports with external dependencies
+class SqlUserRepository(UserRepository):  # Implements domain port
+    def __init__(self, session: SqlAlchemySession):  # External dependency
+        self._session = session
+
+class SmtpEmailAdapter(EmailNotificationPort):  # Implements infrastructure port
+    def __init__(self, smtp_client: SMTPClient):  # External dependency
+        self._smtp_client = smtp_client
+```
+
+### 24. Testing Rules
+- Write unit tests for domain logic without mocking domain objects
+- **Test Ports in Isolation**: Mock secondary ports when testing use cases
+- **Test Adapters Separately**: Test each adapter implementation independently
+- **Integration Testing**: Use in-memory adapters for full workflow testing
+- Test domain events are raised correctly
+- Integration tests should test aggregate boundaries
+- Use builders or factories for test data creation
+- **Contract Testing**: Ensure all adapter implementations satisfy their port contracts
+- **Use Case Testing**: Test each use case independently with mocked dependencies
+
+```python
+# Contract test for all UserRepository implementations
+class UserRepositoryContractTest:
+    def test_save_and_find_user(self, repository: UserRepository):
+        # This test should pass for SqlUserRepository, MongoUserRepository, etc.
+        user = User.create(Email("test@example.com"), "John")
+        repository.save(user)
+        found = repository.find_by_email(Email("test@example.com"))
+        assert found is not None
+        assert found.email == user.email
+
+# Use Case Integration Test
+class TestCreateUserUseCaseIntegration:
+    def test_full_workflow_with_in_memory_adapters(self):
+        # Arrange
+        user_repo = InMemoryUserRepository()
+        email_service = InMemoryEmailService()
+        event_publisher = InMemoryEventPublisher()
+        use_case = CreateUserUseCase(user_repo, email_service, event_publisher)
+        
+        # Act
+        result = use_case.execute(CreateUserCommand("test@example.com", "John"))
+        
+        # Assert
+        assert result.user_id is not None
+        saved_user = user_repo.find_by_email(Email("test@example.com"))
+        assert saved_user is not None
+        assert len(email_service.sent_emails) == 1
+        assert len(event_publisher.published_events) == 1
+
+# Technology-specific adapter testing
+class TestSqlUserRepository:
+    def test_save_user_with_sql_models(self):
+        # Arrange
+        session = create_test_sql_session()
+        repository = SqlUserRepository(session)
+        user = User.create(Email("test@example.com"), "John")
+        
+        # Act
+        repository.save(user)
+        
+        # Assert
+        saved_user = repository.find_by_email(Email("test@example.com"))
+        assert saved_user is not None
+        assert saved_user.email == user.email
+        
+        # Verify SQL model was created correctly
+        user_model = session.query(UserModel).filter_by(email="test@example.com").first()
+        assert user_model is not None
+        assert user_model.name == "John"
+
+class TestMongoUserRepository:
+    def test_save_user_with_mongo_schemas(self):
+        # Arrange
+        mongo_client = create_test_mongo_client()
+        repository = MongoUserRepository(mongo_client)
+        user = User.create(Email("test@example.com"), "John")
+        
+        # Act
+        repository.save(user)
+        
+        # Assert
+        saved_user = repository.find_by_email(Email("test@example.com"))
+        assert saved_user is not None
+        assert saved_user.email == user.email
+```
+
+## Architecture Guardrails
+
+### 25. Infrastructure Replaceability Rules
+- Every external dependency (database, message broker, email provider, cache) MUST be accessed through a port interface
+- Swapping an infrastructure component should require ONLY a new adapter implementation and a DI container change — zero domain or application layer modifications
+- No adapter-specific types (e.g., SQLAlchemy `Session`, MongoDB `Collection`) may appear outside the infrastructure layer
+- Validate replaceability by ensuring all adapter implementations pass the same contract tests for their port
+
+```python
+# Good: DI container is the only place that knows which adapter is active
+class DIContainer:
+    def user_repository(self) -> UserRepository:
+        # Switch from SQL to Mongo by changing this single line
+        return SqlUserRepository(self._sql_session)
+        # return MongoUserRepository(self._mongo_client)
+```
+
+### 26. API Must Not Leak Persistence Models Rules
+- Primary adapters (controllers) MUST return response DTOs, never domain entities or persistence models
+- Request/response schemas (e.g., Pydantic `BaseModel`) live in the primary adapter layer
+- Persistence models (e.g., SQLAlchemy `Model`, MongoDB schemas) live exclusively in secondary adapter packages
+- Domain objects may pass through use cases but MUST be mapped to DTOs before crossing the adapter boundary
+- No ORM-managed object or database-specific annotation should ever appear in an API response
+
+```python
+# BAD: leaking domain entity or persistence model
+@router.get("/{user_id}")
+async def get_user(user_id: str) -> User:  # Domain entity in response
+    ...
+
+# BAD: leaking persistence model
+@router.get("/{user_id}")
+async def get_user(user_id: str) -> UserModel:  # SQLAlchemy model in response
+    ...
+
+# GOOD: dedicated response DTO
+class GetUserResponse(BaseModel):
+    user_id: str
+    email: str
+    name: str
+
+@router.get("/{user_id}", response_model=GetUserResponse)
+async def get_user(user_id: str, use_case: GetUserPort = Depends()) -> GetUserResponse:
+    result = use_case.execute(GetUserQuery(user_id=UserId(user_id)))
+    return GetUserResponse(user_id=result.user_id, email=result.email, name=result.name)
+```
+
+### 27. Asynchronous Workflow Idempotency Rules
+- All asynchronous operations (event handlers, message consumers, background tasks) MUST be idempotent
+- Use idempotency keys or natural deduplication identifiers for every async operation
+- Design handlers so that processing the same message twice produces the same outcome as processing it once
+- Store processing status to detect and skip duplicate executions
+- Never rely on message delivery guarantees alone — always code for at-least-once delivery
+
+```python
+@dataclass(frozen=True)
+class IdempotencyKey:
+    value: str
+
+class SendWelcomeEmailHandler:
+    def __init__(
+        self,
+        email_service: EmailNotificationPort,
+        idempotency_store: IdempotencyStorePort
+    ):
+        self._email_service = email_service
+        self._idempotency_store = idempotency_store
+
+    def handle(self, event: UserCreated) -> None:
+        key = IdempotencyKey(f"welcome_email:{event.user_id.value}")
+        if self._idempotency_store.has_been_processed(key):
+            return  # Already handled — skip
+        self._email_service.send_welcome_email(event.email, event.name)
+        self._idempotency_store.mark_processed(key)
+```
+
+### 28. Bounded Context Rules
+- Each bounded context represents a distinct area of the business with its own ubiquitous language
+- A bounded context MUST have its own domain model — never share entities across contexts
+- Communication between bounded contexts should use domain events or an Anti-Corruption Layer (ACL)
+- Shared concepts between contexts should be expressed as separate value objects in each context, not shared classes
+- Define context maps to document relationships between bounded contexts (e.g., Upstream/Downstream, Conformist, Customer-Supplier)
+- Each bounded context may have its own package structure following the hexagonal layout
+
+```python
+# Context Map Example:
+# [Identity Context] --domain events--> [Notification Context]
+# [Order Context] --ACL--> [Inventory Context]
+
+# BAD: sharing a User entity between contexts
+from identity.domain.model.user import User  # Don't import across contexts
+
+# GOOD: each context defines its own representation
+# identity/domain/model/user.py
+@dataclass
+class User:
+    id: UserId
+    email: Email
+    credentials: HashedPassword
+
+# ordering/domain/model/customer.py — separate concept, same real-world person
+@dataclass(frozen=True)
+class CustomerId:
+    value: str
+
+@dataclass
+class Customer:
+    id: CustomerId
+    name: str
+    shipping_address: Address
+
+# Anti-Corruption Layer translates between contexts
+class IdentityContextACL:
+    """Translates Identity context concepts into Ordering context concepts."""
+    def __init__(self, identity_api: IdentityQueryPort):
+        self._identity_api = identity_api
+
+    def resolve_customer(self, user_id: str) -> Customer:
+        user_data = self._identity_api.get_user(user_id)
+        return Customer(
+            id=CustomerId(user_data.user_id),
+            name=user_data.name,
+            shipping_address=Address(user_data.default_address)
+        )
+```
+
+### 29. Ubiquitous Language Rules
+- Every class, method, variable, and event name in the domain layer MUST use terms from the business domain
+- Maintain a glossary of domain terms per bounded context — developers and domain experts must agree on definitions
+- If a term is ambiguous across contexts, it belongs in separate bounded contexts with context-specific definitions
+- Code reviews should flag technical jargon in the domain layer (e.g., "Manager", "Processor", "Handler", "Helper", "Util")
+- Refactor immediately when the team discovers a better domain term — language drift erodes the model
+
+```python
+# BAD: technical jargon in domain layer
+class OrderProcessor:
+    def process_order(self, data: dict) -> None: ...
+
+class UserDataManager:
+    def handle_user_update(self, payload: dict) -> None: ...
+
+# GOOD: ubiquitous language from the domain
+class OrderFulfillment:
+    def fulfill(self, order: Order) -> Shipment: ...
+
+class Enrollment:
+    def enroll_child(self, child: Child, program: Program) -> EnrollmentConfirmation: ...
+```
+
+### 30. Aggregate Consistency Rules
+- Each aggregate defines a transactional consistency boundary — all invariants within an aggregate are enforced in a single transaction
+- Only ONE aggregate may be modified per transaction — cross-aggregate changes must use eventual consistency via domain events
+- Aggregates reference other aggregates by identity (ID), never by direct object reference
+- Keep aggregates small — large aggregates cause contention and performance issues
+- Aggregate roots are responsible for enforcing all invariants of their internal entities
+- Use optimistic concurrency (version field) to detect conflicting modifications
+
+```python
+@dataclass
+class Order:  # Aggregate Root
+    id: OrderId
+    customer_id: CustomerId  # Reference by ID, not Customer object
+    version: int = 0
+    _line_items: list[OrderLineItem] = field(default_factory=list, init=False)
+    _status: OrderStatus = field(default=OrderStatus.DRAFT, init=False)
+
+    def add_line_item(self, product_id: ProductId, quantity: Quantity, price: Money) -> None:
+        if self._status != OrderStatus.DRAFT:
+            raise OrderNotEditableError(self.id)
+        if len(self._line_items) >= 50:
+            raise OrderLineLimitExceededError(self.id, max_items=50)
+        self._line_items.append(OrderLineItem(product_id, quantity, price))
+
+    def submit(self) -> list[DomainEvent]:
+        if not self._line_items:
+            raise EmptyOrderError(self.id)
+        self._status = OrderStatus.SUBMITTED
+        return [OrderSubmitted(order_id=self.id, customer_id=self.customer_id)]
+
+    # Cross-aggregate side effects happen via events, not direct modification
+    # e.g., OrderSubmitted → InventoryReservationHandler reserves stock
+```
+
+### 31. Event Naming and Structure Convention Rules
+- Event names MUST use past tense to indicate something that already happened
+- Follow the pattern: `{AggregateRoot}{WhatHappened}` (e.g., `OrderSubmitted`, `UserEmailChanged`)
+- Events MUST be immutable (`@dataclass(frozen=True)`)
+- Events MUST include: the aggregate ID, all relevant data needed by handlers, and a timestamp
+- Events SHOULD include a unique event ID for deduplication and traceability
+- Events MUST NOT contain domain objects — use primitive types or value object values only
+- Version events when their schema changes (e.g., `UserCreatedV2`)
+
+```python
+@dataclass(frozen=True)
+class DomainEvent:
+    """Base class for all domain events."""
+    event_id: EventId
+    occurred_at: datetime
+
+@dataclass(frozen=True)
+class OrderSubmitted(DomainEvent):
+    order_id: str          # Primitive, not OrderId — events cross context boundaries
+    customer_id: str
+    total_amount_cents: int
+    line_item_count: int
+
+@dataclass(frozen=True)
+class ChildEnrolledInProgram(DomainEvent):
+    child_id: str
+    program_id: str
+    enrollment_date: str   # ISO 8601 string, not date object
+    guardian_id: str
+
+# BAD event names
+class ProcessOrder(DomainEvent): ...     # Imperative — sounds like a command
+class OrderEvent(DomainEvent): ...       # Too vague
+class OrderData(DomainEvent): ...        # Not an event name
+```
+
+### 32. Architecture Decision Records (ADR) Rules
+- Record significant architectural decisions in `docs/ADR/` using a numbered format (e.g., `0001-use-hexagonal-architecture.md`)
+- An ADR is required when: choosing or changing a framework, database, messaging system, or architectural pattern; deviating from established conventions; making trade-offs that affect multiple bounded contexts
+- Each ADR MUST include: Title, Status (Proposed/Accepted/Deprecated/Superseded), Context, Decision, Consequences
+- ADRs are immutable once accepted — supersede rather than edit
+- Reference ADRs in code comments when a design choice might otherwise seem arbitrary
+- See `docs/ADR/` for all recorded decisions
+
+These integrated rules ensure that Domain Driven Design and Ports & Adapters (Hexagonal Architecture) work together seamlessly in Python implementations. The combination provides clean separation of concerns, testability, and flexibility while maintaining domain focus and proper dependency management.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "tenets",
+  "version": "0.1.0",
+  "description": "Install DDD + Hexagonal Architecture rules into your AI coding tool's config",
+  "bin": {
+    "tenets": "./bin/tenets.js"
+  },
+  "scripts": {
+    "bundle": "node scripts/bundle-content.js",
+    "prepublishOnly": "npm run bundle"
+  },
+  "keywords": [
+    "ddd",
+    "hexagonal-architecture",
+    "coding-standards",
+    "ai-agents",
+    "claude",
+    "cursor",
+    "copilot"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": [
+    "bin/",
+    "src/",
+    "bundled/"
+  ]
+}

--- a/cli/scripts/bundle-content.js
+++ b/cli/scripts/bundle-content.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+/**
+ * Copies the latest content from the repo root into cli/bundled/
+ * for offline fallback. Run before publishing: `npm run bundle`
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const BUNDLED_DIR = path.resolve(__dirname, '..', 'bundled');
+const BUNDLED_CONTEXT_DIR = path.join(BUNDLED_DIR, 'context');
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function copyFile(src, dest) {
+  const content = fs.readFileSync(src, 'utf-8');
+  fs.writeFileSync(dest, content, 'utf-8');
+  console.log(`  ${path.relative(REPO_ROOT, src)} -> ${path.relative(REPO_ROOT, dest)}`);
+}
+
+console.log('Bundling content for offline fallback...\n');
+
+ensureDir(BUNDLED_DIR);
+ensureDir(BUNDLED_CONTEXT_DIR);
+
+copyFile(
+  path.join(REPO_ROOT, 'domain_driven_design_hexagonal_arhictecture_python_rules.md'),
+  path.join(BUNDLED_DIR, 'rules.md')
+);
+
+const contextFiles = [
+  'context/architecture/01-hexagonal-primer.md',
+  'context/architecture/02-components.md',
+  'context/global/project_structure.md',
+];
+
+for (const file of contextFiles) {
+  const src = path.join(REPO_ROOT, file);
+  const dest = path.join(BUNDLED_CONTEXT_DIR, path.basename(file));
+
+  if (fs.existsSync(src)) {
+    copyFile(src, dest);
+  } else {
+    console.log(`  SKIP: ${file} (not found)`);
+  }
+}
+
+console.log('\nDone. Bundled content is ready.');

--- a/cli/src/commands/init.js
+++ b/cli/src/commands/init.js
@@ -1,0 +1,57 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { TOOLS } = require('../constants');
+const { fetchContent, assembleContent, computeHash } = require('../services/content-fetcher');
+const { writeFile } = require('../services/file-writer');
+const { updateToolEntry } = require('../services/config-tracker');
+const { promptToolSelection, promptFileConflict } = require('../ui/prompts');
+const { logger } = require('../ui/logger');
+
+function resolveToolFromFlags(args) {
+  for (const [key, tool] of Object.entries(TOOLS)) {
+    if (args.includes(tool.flag)) {
+      return key;
+    }
+  }
+  return null;
+}
+
+async function initCommand(args) {
+  let toolKey = resolveToolFromFlags(args);
+
+  if (!toolKey) {
+    toolKey = await promptToolSelection(TOOLS);
+    if (!toolKey) {
+      logger.error('Invalid selection. Aborting.');
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  const tool = TOOLS[toolKey];
+  const targetPath = path.resolve(process.cwd(), tool.targetFile);
+
+  let mode = 'replace';
+  if (fs.existsSync(targetPath)) {
+    mode = await promptFileConflict(targetPath);
+    if (mode === 'cancel') {
+      logger.info('Cancelled.');
+      return;
+    }
+  }
+
+  const { rules, contextFiles } = await fetchContent();
+  const assembled = assembleContent(rules, contextFiles);
+  const hash = computeHash(assembled);
+
+  writeFile(targetPath, assembled, mode);
+  updateToolEntry(toolKey, tool.targetFile, hash, mode);
+
+  logger.blank();
+  logger.success(`Rules installed to ${tool.targetFile}`);
+  logger.dim(`  Tool: ${tool.name}`);
+  logger.dim(`  Mode: ${mode}`);
+  logger.dim(`  Run \`npx tenets update\` to update later.`);
+}
+
+module.exports = { initCommand };

--- a/cli/src/commands/update.js
+++ b/cli/src/commands/update.js
@@ -1,0 +1,53 @@
+const path = require('node:path');
+const { readConfig, updateToolEntry } = require('../services/config-tracker');
+const { fetchContent, assembleContent, computeHash } = require('../services/content-fetcher');
+const { writeFile, replaceMarkedContent } = require('../services/file-writer');
+const { logger } = require('../ui/logger');
+
+async function updateCommand() {
+  const config = readConfig();
+
+  if (!config || !config.tools || Object.keys(config.tools).length === 0) {
+    logger.error(
+      'No tools configured. Run `npx tenets init` first.'
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const { rules, contextFiles } = await fetchContent();
+  const assembled = assembleContent(rules, contextFiles);
+  const newHash = computeHash(assembled);
+
+  let updatedCount = 0;
+
+  for (const [toolKey, entry] of Object.entries(config.tools)) {
+    const targetPath = path.resolve(process.cwd(), entry.targetFile);
+
+    if (entry.contentHash === newHash) {
+      logger.success(`${entry.targetFile} — already up to date.`);
+      continue;
+    }
+
+    const replaced = replaceMarkedContent(targetPath, assembled);
+
+    if (replaced) {
+      logger.success(`${entry.targetFile} — updated (marker replacement).`);
+    } else {
+      writeFile(targetPath, assembled, entry.mode || 'replace');
+      logger.success(`${entry.targetFile} — updated (full ${entry.mode || 'replace'}).`);
+    }
+
+    updateToolEntry(toolKey, entry.targetFile, newHash, entry.mode || 'replace');
+    updatedCount++;
+  }
+
+  logger.blank();
+  if (updatedCount === 0) {
+    logger.info('All tools are up to date.');
+  } else {
+    logger.success(`Updated ${updatedCount} file(s).`);
+  }
+}
+
+module.exports = { updateCommand };

--- a/cli/src/constants.js
+++ b/cli/src/constants.js
@@ -1,0 +1,52 @@
+const GITHUB_RAW_BASE =
+  'https://raw.githubusercontent.com/bardiakhosravi/ai-agent-backend-standards/main';
+
+const GITHUB_URLS = {
+  rules: `${GITHUB_RAW_BASE}/domain_driven_design_hexagonal_arhictecture_python_rules.md`,
+  context: [
+    {
+      url: `${GITHUB_RAW_BASE}/context/architecture/01-hexagonal-primer.md`,
+      title: 'Hexagonal Architecture Primer',
+    },
+    {
+      url: `${GITHUB_RAW_BASE}/context/architecture/02-components.md`,
+      title: 'Components',
+    },
+    {
+      url: `${GITHUB_RAW_BASE}/context/global/project_structure.md`,
+      title: 'Project Structure',
+    },
+  ],
+};
+
+const TOOLS = {
+  claude: {
+    name: 'Claude Code',
+    flag: '--claude',
+    targetFile: 'CLAUDE.md',
+  },
+  cursor: {
+    name: 'Cursor',
+    flag: '--cursor',
+    targetFile: '.cursorrules',
+  },
+  copilot: {
+    name: 'GitHub Copilot',
+    flag: '--copilot',
+    targetFile: '.github/copilot-instructions.md',
+  },
+  agents: {
+    name: 'AGENTS.md',
+    flag: '--agents',
+    targetFile: 'AGENTS.md',
+  },
+};
+
+const CONFIG_FILE = '.tenets.json';
+
+const MARKERS = {
+  start: '<!-- tenets:start -->',
+  end: '<!-- tenets:end -->',
+};
+
+module.exports = { GITHUB_RAW_BASE, GITHUB_URLS, TOOLS, CONFIG_FILE, MARKERS };

--- a/cli/src/services/config-tracker.js
+++ b/cli/src/services/config-tracker.js
@@ -1,0 +1,40 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { CONFIG_FILE } = require('../constants');
+
+function configPath() {
+  return path.resolve(process.cwd(), CONFIG_FILE);
+}
+
+function readConfig() {
+  const p = configPath();
+  if (!fs.existsSync(p)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeConfig(config) {
+  fs.writeFileSync(configPath(), JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+
+function updateToolEntry(toolKey, targetFile, contentHash, mode) {
+  const config = readConfig() || { tools: {} };
+
+  config.tools[toolKey] = {
+    targetFile,
+    contentHash,
+    mode,
+    installedAt: config.tools[toolKey]?.installedAt || new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  writeConfig(config);
+}
+
+module.exports = { readConfig, writeConfig, updateToolEntry };

--- a/cli/src/services/content-fetcher.js
+++ b/cli/src/services/content-fetcher.js
@@ -1,0 +1,104 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { GITHUB_URLS, MARKERS } = require('../constants');
+const { logger } = require('../ui/logger');
+
+const BUNDLED_DIR = path.join(__dirname, '..', '..', 'bundled');
+
+async function fetchUrl(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    return await response.text();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function fetchFromGitHub() {
+  logger.info('Fetching latest rules from GitHub...');
+
+  const rules = await fetchUrl(GITHUB_URLS.rules);
+
+  const contextFiles = [];
+  for (const entry of GITHUB_URLS.context) {
+    const content = await fetchUrl(entry.url);
+    contextFiles.push({ title: entry.title, content });
+  }
+
+  return { rules, contextFiles };
+}
+
+function loadBundled() {
+  logger.info('Using bundled content (offline fallback)...');
+
+  const rulesPath = path.join(BUNDLED_DIR, 'rules.md');
+  if (!fs.existsSync(rulesPath)) {
+    throw new Error(
+      'Bundled rules not found. Please reinstall the package.'
+    );
+  }
+
+  const rules = fs.readFileSync(rulesPath, 'utf-8');
+
+  const contextDir = path.join(BUNDLED_DIR, 'context');
+  const contextFiles = [];
+
+  const contextEntries = [
+    { file: '01-hexagonal-primer.md', title: 'Hexagonal Architecture Primer' },
+    { file: '02-components.md', title: 'Components' },
+    { file: 'project_structure.md', title: 'Project Structure' },
+  ];
+
+  for (const entry of contextEntries) {
+    const filePath = path.join(contextDir, entry.file);
+    if (fs.existsSync(filePath)) {
+      contextFiles.push({
+        title: entry.title,
+        content: fs.readFileSync(filePath, 'utf-8'),
+      });
+    }
+  }
+
+  return { rules, contextFiles };
+}
+
+async function fetchContent() {
+  try {
+    return await fetchFromGitHub();
+  } catch {
+    logger.warn('Could not fetch from GitHub, using bundled content.');
+    return loadBundled();
+  }
+}
+
+function assembleContent(rules, contextFiles) {
+  const parts = [
+    MARKERS.start,
+    '# DDD + Hexagonal Architecture Rules',
+    '',
+    '> Installed by tenets. Run `npx tenets update` to update.',
+    '',
+    rules.trim(),
+  ];
+
+  for (const ctx of contextFiles) {
+    parts.push('', '---', `## Appendix: ${ctx.title}`, '', ctx.content.trim());
+  }
+
+  parts.push('', MARKERS.end, '');
+
+  return parts.join('\n');
+}
+
+function computeHash(content) {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+module.exports = { fetchContent, assembleContent, computeHash };

--- a/cli/src/services/file-writer.js
+++ b/cli/src/services/file-writer.js
@@ -1,0 +1,46 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { MARKERS } = require('../constants');
+
+function ensureDir(filePath) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function writeFile(filePath, content, mode) {
+  ensureDir(filePath);
+
+  if (mode === 'append') {
+    const existing = fs.existsSync(filePath)
+      ? fs.readFileSync(filePath, 'utf-8')
+      : '';
+    const separator = existing.length > 0 && !existing.endsWith('\n') ? '\n\n' : '\n';
+    fs.writeFileSync(filePath, existing + separator + content, 'utf-8');
+  } else {
+    fs.writeFileSync(filePath, content, 'utf-8');
+  }
+}
+
+function replaceMarkedContent(filePath, newContent) {
+  if (!fs.existsSync(filePath)) {
+    return false;
+  }
+
+  const existing = fs.readFileSync(filePath, 'utf-8');
+  const startIdx = existing.indexOf(MARKERS.start);
+  const endIdx = existing.indexOf(MARKERS.end);
+
+  if (startIdx === -1 || endIdx === -1) {
+    return false;
+  }
+
+  const before = existing.substring(0, startIdx);
+  const after = existing.substring(endIdx + MARKERS.end.length);
+
+  fs.writeFileSync(filePath, before + newContent.trimEnd() + after, 'utf-8');
+  return true;
+}
+
+module.exports = { writeFile, replaceMarkedContent };

--- a/cli/src/ui/logger.js
+++ b/cli/src/ui/logger.js
@@ -1,0 +1,36 @@
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[2m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const RED = '\x1b[31m';
+const CYAN = '\x1b[36m';
+
+const logger = {
+  info(msg) {
+    console.log(`${CYAN}info${RESET} ${msg}`);
+  },
+  success(msg) {
+    console.log(`${GREEN}${BOLD}\u2714${RESET} ${msg}`);
+  },
+  warn(msg) {
+    console.log(`${YELLOW}warn${RESET} ${msg}`);
+  },
+  error(msg) {
+    console.error(`${RED}${BOLD}\u2716${RESET} ${msg}`);
+  },
+  dim(msg) {
+    console.log(`${DIM}${msg}${RESET}`);
+  },
+  blank() {
+    console.log();
+  },
+  banner() {
+    console.log(
+      `${BOLD}tenets${RESET} ${DIM}— DDD + Hexagonal Architecture rules for AI agents${RESET}`
+    );
+    console.log();
+  },
+};
+
+module.exports = { logger };

--- a/cli/src/ui/prompts.js
+++ b/cli/src/ui/prompts.js
@@ -1,0 +1,68 @@
+const readline = require('node:readline');
+
+function createInterface() {
+  return readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+}
+
+function ask(rl, question) {
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => resolve(answer.trim()));
+  });
+}
+
+async function promptToolSelection(tools) {
+  const rl = createInterface();
+  const entries = Object.entries(tools);
+
+  console.log('Which AI tool do you want to install rules for?\n');
+  entries.forEach(([key, tool], i) => {
+    console.log(`  ${i + 1}) ${tool.name} (${tool.targetFile})`);
+  });
+  console.log();
+
+  try {
+    const answer = await ask(rl, 'Enter number: ');
+    const index = parseInt(answer, 10) - 1;
+
+    if (index < 0 || index >= entries.length || Number.isNaN(index)) {
+      return null;
+    }
+
+    return entries[index][0];
+  } finally {
+    rl.close();
+  }
+}
+
+async function promptFileConflict(filePath) {
+  const rl = createInterface();
+
+  console.log(`\nFile already exists: ${filePath}\n`);
+  console.log('  1) Replace entire file');
+  console.log('  2) Append to existing file');
+  console.log('  3) Cancel');
+  console.log();
+
+  try {
+    const answer = await ask(rl, 'Enter number: ');
+    const choice = parseInt(answer, 10);
+
+    switch (choice) {
+      case 1:
+        return 'replace';
+      case 2:
+        return 'append';
+      case 3:
+        return 'cancel';
+      default:
+        return 'cancel';
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+module.exports = { promptToolSelection, promptFileConflict };

--- a/context/architecture/01-hexagonal-primer.md
+++ b/context/architecture/01-hexagonal-primer.md
@@ -1,0 +1,12 @@
+# Hexagonal Architecture Primer
+
+Hexagonal architecture, also known as Ports and Adapters, is a design pattern that separates business logic from technical concerns. It aims to isolate the core domain from external systems, making the application more maintainable, testable, and adaptable to change.
+
+This architecture organizes the system into four main components:
+
+- **Domain**: The core business logic and rules, independent of frameworks and technologies.  
+- **Application**: Coordinates domain logic and defines application-specific tasks.  
+- **Ports**: Interfaces that define communication between the application and the outside world.  
+- **Adapters**: Implementations of ports that connect to external systems like databases, APIs, or user interfaces.
+
+See [components.md](./components.md) for detailed responsibilities and checklists.

--- a/context/architecture/02-components.md
+++ b/context/architecture/02-components.md
@@ -1,0 +1,178 @@
+# Components of Hexagonal Architecture
+
+Use hexagonal architecture to separate business logic, application orchestration, and technical concerns. Follow strict dependency rules and component boundaries to ensure modularity, testability, and adaptability.
+
+---
+
+## Domain
+
+**Responsibilities:**  
+- Encapsulate business rules, logic, and invariants.  
+- Represent core concepts, entities, value objects, and aggregates.  
+- Operate independently from external systems, frameworks, or infrastructure.
+
+**Must:**  
+- Contain pure business logic only.  
+- Behave deterministically based on inputs.  
+- Exposes behavior; application may call these, but domain must not depend on application or ports.
+
+**Must Not:**  
+- Depend on application, adapters, ports, or infrastructure.  
+- Leak infrastructure concerns (e.g., database code) into domain logic.  
+- Include technical or framework-specific annotations.  
+- Use domain objects for data transport or serialization.
+
+**Boundaries:**  
+- No dependencies on adapters, frameworks, or external services.  
+- Communicate only through defined ports with the application layer.
+
+---
+
+## Application
+
+**Responsibilities:**  
+- Orchestrate use cases, workflows, and application-specific logic.  
+- Coordinate domain objects to fulfill business requirements.  
+- Manage transactions, security, and authorization if applicable.  
+- Define and expose inbound ports; use outbound ports.
+
+**Must:**  
+- Delegate business logic exclusively to the domain.  
+- Be stateless and idempotent where possible.  
+- Depend only on domain logic and port interfaces.
+
+**Must Not:**  
+- Contain business rules.  
+- Depend on infrastructure or adapter implementations.  
+- Mix application and infrastructure responsibilities.
+
+**Boundaries:**  
+- Expose inbound ports and use outbound ports.  
+- Never depend on adapter implementations directly.
+
+---
+
+## Ports
+
+### Inbound Ports
+
+**Responsibilities:**  
+- Define interfaces to drive application use cases (commands, queries).  
+- Specify system capabilities for external actors.
+
+**Must:**  
+- Be purely abstract, language- and technology-agnostic.  
+- Be declared in the application layer.
+
+**Must Not:**  
+- Leak technical details (e.g., HTTP, messaging) into definitions.  
+- Depend on adapter-specific data structures.
+
+**Boundaries:**  
+- Implemented only by inbound adapters.
+
+### Outbound Ports
+
+**Responsibilities:**  
+- Define interfaces for required external operations (persistence, messaging).  
+- Specify system needs from the outside world.
+
+**Must:**  
+- Be purely abstract and represent business needs, not technical mechanisms.  
+- Be declared in the application layer.
+
+**Must Not:**  
+- Match specific databases or external APIs.  
+- Include technical error handling or transport concerns.
+
+**Boundaries:**  
+- Implemented only by outbound adapters.
+
+---
+
+## Adapters
+
+### Inbound Adapters
+
+**Responsibilities:**  
+- Translate external requests into calls to inbound ports.  
+- Handle protocol-specific concerns (parsing, validation, authentication).
+
+**Must:**  
+- Implement inbound ports only.  
+- Depend on external protocols and frameworks.  
+- Validate inputs rigorously.
+
+**Must Not:**  
+- Contain business or workflow logic.  
+- Access domain or application internals directly.  
+- Skip validation or leak invalid data.
+
+**Boundaries:**  
+- Do not depend on other adapters or infrastructure details.
+
+### Outbound Adapters
+
+**Responsibilities:**  
+- Implement outbound ports to connect with infrastructure (databases, APIs, message brokers).  
+- Translate domain/application requests into external system interactions.
+
+**Must:**  
+- Implement outbound ports only.  
+- Handle errors properly and translate to port-level abstractions.  
+- Depend on external technologies and protocols.
+
+**Must Not:**  
+- Contain business or application logic.  
+- Know use case orchestration details.  
+- Leak external data structures into domain or application.  
+- Allow infrastructure failures to propagate as technical exceptions.
+
+**Boundaries:**  
+- Do not depend on other adapters, application, or domain internals.
+
+---
+
+## Boundaries & Allowed Dependencies
+
+- **Domain:** MUST have no dependencies.  
+- **Application:** MUST depend only on domain and port interfaces.  
+- **Ports:** MUST be pure interfaces; MUST NOT depend on adapters or infrastructure.  
+- **Adapters:** MUST depend on ports and external technologies ONLY; MUST NOT depend on domain or application internals.
+
+**Allowed Interaction Flow:**  
+Inbound adapters → inbound ports → application → domain → outbound ports → outbound adapters.
+
+**Prohibited Interactions:**  
+- Adapters MUST NOT call domain or application internals directly.  
+- Domain MUST NOT depend on application, ports, or adapters.  
+- Application MUST NOT depend on adapters or infrastructure.
+
+---
+
+## Decision Table
+
+| Concern/Responsibility        | Domain | Application | Ports | Adapters |
+|------------------------------|--------|-------------|-------|----------|
+| Business rules               | MUST   | MUST NOT    | MUST NOT | MUST NOT |
+| Use case orchestration       | MUST NOT | MUST     | MUST NOT | MUST NOT |
+| Interface definition         | MUST NOT | MUST      | MUST    | MUST NOT |
+| Protocol translation         | MUST NOT | MUST NOT  | MUST NOT | MUST    |
+| Infrastructure integration   | MUST NOT | MUST NOT  | MUST NOT | MUST    |
+| External communication       | MUST NOT | MUST NOT  | MUST NOT | MUST    |
+| Dependency on frameworks     | MUST NOT | MUST NOT  | MUST NOT | MUST    |
+| Statelessness               | MUST    | MUST       | MUST    | MUST    |
+
+---
+
+## Agent Directive
+
+1. **Respect component responsibilities:** Agents must assign tasks and logic according to component roles.  
+2. **Enforce dependency rules:** Agents must not create or allow prohibited dependencies.  
+3. **Use ports as boundaries:** Agents must communicate between layers strictly via ports.  
+4. **Avoid embedding logic in adapters:** Agents must keep adapters free of business and orchestration logic.  
+5. **Validate inputs at inbound adapters:** Agents must ensure all external data is validated before reaching application or domain.  
+6. **Maintain purity of domain:** Agents must prevent technical concerns from leaking into domain logic.  
+7. **Follow interaction flow:** Agents must route communication through the allowed path only.  
+8. **Ensure testability:** Agents must design components to be independently testable.  
+9. **Report violations:** Agents must flag any breach of these rules immediately.

--- a/context/global/project_structure.md
+++ b/context/global/project_structure.md
@@ -1,0 +1,143 @@
+# Hexagonal Architecture Project Structure
+
+This document defines the standard folder structure for Python backend services following Domain Driven Design and Hexagonal Architecture (Ports & Adapters) patterns.
+
+## Overview
+
+- Organize by hexagonal architecture layers with clear port placement
+- **Domain ports**: Repository interfaces and domain service ports in domain layer
+- **Primary ports**: (driving) define application use cases - belong in application layer
+- **Infrastructure secondary ports** (email, messaging, external APIs) - belong in application layer
+- **Secondary adapters**: Organize by technology for shared infrastructure and easier maintenance
+- **Technology-specific models**: Persistence models live within their respective technology adapters
+- **Configuration layer**: Cross-cutting concerns that wire all layers together
+- Domain and application layers should only depend on their respective port interfaces
+- Adapters layer contains all adapter implementations
+
+## Standard Structure
+
+```
+src/
+├── domain/
+│   ├── model/
+│   │   ├── user/
+│   │   │   ├── user.py              # Entity
+│   │   │   └── email.py             # Value Object
+│   │   └── order/
+│   ├── ports/                       # Domain Ports (Secondary)
+│   │   ├── user_repository.py       # Repository interface (domain concept)
+│   │   ├── order_repository.py
+│   │   ├── pricing_service_port.py  # Domain service interface
+│   │   ├── inventory_service_port.py
+│   │   └── domain_event_store_port.py  # Domain-specific event storage
+│   └── events/                      # Domain Events
+├── application/
+│   ├── ports/
+│   │   ├── primary/                 # Primary Ports (Use Cases)
+│   │   │   ├── create_user_port.py          # Primary Port
+│   │   │   ├── change_user_email_port.py    # Primary Port
+│   │   │   └── deactivate_user_port.py      # Primary Port
+│   │   └── secondary/               # Infrastructure Ports (Secondary)
+│   │       ├── email_notification_port.py   # Infrastructure service
+│   │       ├── event_publisher_port.py      # Infrastructure service
+│   │       └── payment_gateway_port.py      # Infrastructure service
+│   ├── use_cases/
+│   │   ├── create_user_use_case.py          # Use Case (Primary Port Implementation)
+│   │   ├── change_user_email_use_case.py    # Use Case (Primary Port Implementation)
+│   │   └── deactivate_user_use_case.py      # Use Case (Primary Port Implementation)
+│   ├── commands/
+│   ├── queries/
+│   └── handlers/
+├── adapters/
+│   ├── primary/
+│   │   ├── web/
+│   │   │   ├── user_controller.py       # Primary Adapter
+│   │   │   └── order_controller.py
+│   │   ├── cli/
+│   │   └── messaging/
+│   └── secondary/                       # Organized by Technology
+│       ├── sql/
+│       │   ├── models/                          # SQLAlchemy models
+│       │   │   ├── user_model.py
+│       │   │   └── order_model.py
+│       │   ├── base_sql_repository.py          # Shared base class
+│       │   ├── sql_connection_manager.py       # Shared connection handling
+│       │   ├── sql_user_repository.py          # Implements UserRepository
+│       │   ├── sql_order_repository.py         # Implements OrderRepository
+│       │   └── sql_domain_event_store.py       # Implements DomainEventStorePort
+│       ├── mongodb/
+│       │   ├── schemas/                         # MongoDB schemas
+│       │   │   ├── user_schema.py
+│       │   │   └── order_schema.py
+│       │   ├── mongo_connection.py             # Shared connection
+│       │   ├── mongo_user_repository.py        # Implements UserRepository
+│       │   └── mongo_order_repository.py       # Implements OrderRepository
+│       ├── http/
+│       │   ├── base_http_client.py             # Shared HTTP utilities
+│       │   ├── http_retry_policy.py            # Shared retry logic
+│       │   ├── http_pricing_service.py         # Implements PricingServicePort
+│       │   ├── http_payment_gateway.py         # Implements PaymentGatewayPort
+│       │   └── http_email_service.py           # Implements EmailNotificationPort
+│       ├── messaging/
+│       │   ├── rabbitmq_connection.py          # Shared connection
+│       │   ├── rabbitmq_event_publisher.py     # Implements EventPublisherPort
+│       │   └── rabbitmq_notification_sender.py # Implements NotificationPort
+│       └── redis/
+│           ├── redis_connection.py             # Shared connection
+│           ├── redis_cache_service.py          # Implements CacheServicePort
+│           └── redis_session_store.py          # Implements SessionStorePort
+└── configuration/                           # Cross-cutting Configuration Layer
+    ├── di_container.py                      # Dependency injection container
+    ├── database_config.py                  # Database configuration
+    ├── app_settings.py                     # Application settings
+    └── environment_config.py               # Environment-specific config
+```
+
+## Layer Descriptions
+
+### Domain Layer (`src/domain/`)
+- **model/**: Contains Entities, Value Objects, and Aggregates organized by domain concept
+- **ports/**: Repository interfaces and domain service ports (secondary ports from domain perspective)
+- **events/**: Domain event definitions
+
+### Application Layer (`src/application/`)
+- **ports/primary/**: Primary ports defining use case interfaces
+- **ports/secondary/**: Infrastructure service ports (email, messaging, external APIs)
+- **use_cases/**: Use case implementations that implement primary ports
+- **commands/**: Command objects for write operations
+- **queries/**: Query objects for read operations
+- **handlers/**: Event handlers and other cross-cutting handlers
+
+### Adapters Layer (`src/adapters/`)
+- **primary/**: Entry point adapters (web controllers, CLI, message consumers)
+- **secondary/**: Organized by technology (sql, mongodb, http, messaging, redis, etc.)
+  - Each technology folder contains its own models/schemas and adapter implementations
+  - Shared infrastructure code (connections, base classes, utilities) lives within technology folders
+
+### Configuration Layer (`src/configuration/`)
+- Dependency injection container
+- Database and infrastructure configuration
+- Environment-specific settings
+- Wires all layers together at application startup
+
+## Key Principles
+
+1. **Port Placement**:
+   - Domain ports (repositories, domain services) → `domain/ports/`
+   - Primary ports (use case interfaces) → `application/ports/primary/`
+   - Infrastructure ports (external services) → `application/ports/secondary/`
+
+2. **Adapter Organization**:
+   - Primary adapters → `infrastructure/adapters/primary/` (organized by adapter type)
+   - Secondary adapters → `infrastructure/adapters/secondary/` (organized by technology)
+
+3. **Technology-Specific Models**:
+   - SQLAlchemy models → `infrastructure/adapters/secondary/sql/models/`
+   - MongoDB schemas → `infrastructure/adapters/secondary/mongodb/schemas/`
+   - Keep persistence models close to their adapter implementations
+
+4. **Dependency Direction**:
+   - Domain layer → No external dependencies
+   - Application layer → Depends on domain ports only
+   - Infrastructure layer → Implements all ports, depends on external frameworks
+   - Configuration layer → Depends on all layers to wire them together

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,130 @@
+- entities vs values objects
+- not coupling ports to adapter speicifc details. 
+- exception handling
+
+# Add Mapper Rules
+
+
+### 25. Domain Object Mapping Rules
+- **Centralized Mapping**: All mappings from domain objects to simple types (dicts, JSON, DTOs) MUST be done in dedicated mapper files
+- **Mapper Location**: Place mappers in `infrastructure/adapters/primary/{technology}/mappers.py` for primary adapters
+- **Mapper Location**: Place mappers in `infrastructure/adapters/secondary/{technology}/mappers.py` for secondary adapters
+- **Pure Functions**: Mappers should be pure functions with no side effects
+- **Type Safety**: Use explicit type hints for all mapper functions
+- **Immutable Mapping**: Never modify domain objects during mapping
+- **Complete Mapping**: Map all necessary fields, including nested value objects
+- **String Conversion**: Convert domain value objects to strings using `str()` when needed for serialization
+
+```python
+# Good Example - infrastructure/adapters/primary/letta/mappers.py
+def map_poi_to_letta_poi(pois: List[PointOfInterest]) -> str:
+    """Map POI domain objects to Letta POI format."""
+    poi_dicts = [
+        {
+            "id": str(poi.id),  # Convert value object to string
+            "name": poi.name,
+            "description": poi.description,
+            "location": {
+                "latitude": poi.location.latitude,
+                "longitude": poi.location.longitude,
+            },
+        }
+        for poi in pois
+    ]
+    return json.dumps(poi_dicts)
+
+# Bad Example - Don't do mapping inline in adapters
+class SomeAdapter:
+    def some_method(self, poi: PointOfInterest):
+        # DON'T do this - mapping should be in mappers.py
+        return {
+            "id": poi.id,
+            "name": poi.name
+        }
+```
+
+```python
+
+
+
+# Recommended Structure
+
+/context/
+  README.md                          # map of the territory + how to use this context
+
+  # Level 1 — Concepts (what & why)
+  /architecture/
+    00-overview.md                   # hexagonal + DDD in one page (links to below)
+    hexagonal/
+      01-hexagonal-primer.md         # short, agent-optimized summary
+      02-components.md               # Domain, Application, Ports, Adapters (definitions & purpose)
+      03-boundaries.md               # dependency rules (who can import whom), layering, packaging
+      04-c4-cheatsheet.md            # C4 bullets for L1–L3
+    ddd/
+      01-ddd-primer.md               # ubiquitous language, bounded contexts, aggregates
+      02-strategic-patterns.md       # contexts, context maps, anti-corruption layers
+      03-tactical-patterns.md        # entities, VOs, domain services, repositories, domain events
+
+  # Level 2 — Rules & non-negotiables (how)
+  /standards/
+    domain.md                        # invariants, entities/VOs, events, error taxonomy
+    application.md                   # use cases, transactions, idempotency, mapping errors
+    ports.md                         # inbound/outbound definitions, stability, versioning
+    adapters.md                      # http/db/messaging adapters; resiliency, retries, timeouts
+    repositories.md                  # persistence rules, mapping, no leakage, pagination rules
+    testing.md                       # unit vs contract vs adapter tests; fixtures/fakes/stubs
+    naming.md                        # UL alignment, events past-tense, package names
+    security.md                      # secrets, validation, authZ/IAM seam placement
+    observability.md                 # structured logs, metrics, traces; where to emit
+    adrs.md                          # when to write one, format, examples
+    quality-gates.md                 # the single checklist devs/agents must pass
+
+  # Level 3 — Recipes & examples (do this)
+  /recipes/
+    ports/
+      define-outbound-port.md        # template + gotchas + mini code
+      versioning-outbound-port.md
+    application/
+      implement-usecase.md
+      idempotency-patterns.md
+    adapters/
+      http-inbound-fastapi.md
+      payment-gateway-outbound.md
+      repository-postgres.md
+      message-publisher-kafka.md
+    patterns/
+      domain-events.md
+      saga-process-manager.md
+      cqrs.md
+      event-sourcing.md
+      api-standards.md               # request/response shapes, error envelopes
+    checklists/
+      feature-slice-checklist.md     # from UL → tests
+      adapter-readiness-checklist.md
+      release-readiness-checklist.md
+
+  # Schemas agents can parse (optional, but powerful)
+  /schemas/
+    project-manifest.schema.json
+    bounded-context.schema.json
+    ports.schema.json
+    aggregates.schema.json
+
+  # Example domain we’ll grow over time
+  /examples/
+    orders/                          # bounded context: Orders
+      00-readme.md                   # what the example covers
+      ubiquitous-language.yaml
+      aggregates.yaml
+      ports.yaml
+      specs/
+        place-order.md
+        confirm-order.md
+        pay-for-order.md
+      snippets/                      # tiny, focused code snippets (no full app yet)
+        domain_entities.py
+        application_ports.py
+        outbound_port_contract_tests.py
+        adapter_fake_payment_gateway.py
+
+

--- a/vision.md
+++ b/vision.md
@@ -1,0 +1,17 @@
+# Core Vision
+
+- The project’s purpose is to make it easy for developers and teams to build services using Hexagonal Architecture and Domain-Driven Design (DDD).
+
+- The project will provide coding agents the context required to effectively build and evolve a service
+according to hexagonal architecture and DDD best practices. it will provide clear, opinionated, extensible, customizable guidelines for coding agents to design services according to these practices and patterns. 
+
+- it will also provide tooling as required
+
+- It should support developers through the entire spectrum:
+    1.	Getting started with a new service.
+    2.	Evolving an existing service.
+	3.	Building multiple services that interact with each other.
+
+- Over time, the project may evolve into a platform for building and managing hexagonal services effectively, including tooling for visualization, assessment, and management. It will also provide AI tooling to domain modeling, event storming, domain driven design activities.
+
+- this project will make sure developer experience is at the forefront of what ever is created


### PR DESCRIPTION
## Summary
- Add `tenets` CLI (`npx tenets init`) that installs DDD + Hexagonal Architecture rules into AI tool config files
- Supports Claude Code, Cursor, GitHub Copilot, and AGENTS.md
- Zero dependencies, GitHub fetch with bundled fallback, marker-based updates via `npx tenets update`
- Rebrand README around "Tenets" with Quick Start docs and tool support table
- Add context files (hexagonal primer, components, project structure) and vision doc

## Test plan
- [x] `tenets --help` displays usage
- [x] `tenets init --claude` creates CLAUDE.md with markers and content
- [x] `tenets init --cursor` creates .cursorrules
- [x] `tenets init --copilot` creates .github/copilot-instructions.md (including directory)
- [x] `tenets update` detects "already up to date" when no changes
- [x] `.tenets.json` tracks all installed tools with hashes and timestamps
- [ ] Test interactive mode (no flags)
- [ ] Test append mode on existing file
- [ ] Verify GitHub fetch works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)