### PR TITLE
Add Tenets code review agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ npx tenets init --claude
 npx tenets init --claude        # Claude Code (multi-layer integration)
 npx tenets init --cursor        # writes to .cursorrules
 npx tenets init --copilot       # writes to .github/copilot-instructions.md
+npx tenets init --code-review-agent  # writes a code review agent prompt
 npx tenets init --agents        # writes to AGENTS.md
 ```
 
@@ -42,6 +43,7 @@ npx tenets init --agents        # writes to AGENTS.md
 | `--claude` | Claude Code | Rules, skill, hook, CLAUDE.md snippet (see below) |
 | `--cursor` | Cursor | `.cursorrules` |
 | `--copilot` | GitHub Copilot | `.github/copilot-instructions.md` |
+| `--code-review-agent` | Code review agent | `.tenets/agents/code-review-agent.md` |
 | `--agents` | AGENTS.md | `AGENTS.md` |
 
 Flags are composable — install multiple integrations in one step:
@@ -57,6 +59,38 @@ npx tenets update
 ```
 
 This pulls the latest rules and updates all previously installed files — including the Spec-Kit preset if you installed it. If you're upgrading from an older version, the CLI will detect this and walk you through the migration.
+
+---
+
+## Code Review Agent
+
+Tenets can install a repository-local code review agent prompt:
+
+```bash
+npx tenets init --code-review-agent
+```
+
+This writes `.tenets/agents/code-review-agent.md`, a standalone reviewer contract that a parent agent can load after it writes code. The code review agent is instructed to inspect the diff, classify changed files by architectural layer, check the implementation against the Tenets rulebook, and return feedback in a structured format:
+
+- `pass` when no blocking architecture issues are found
+- `changes_requested` when the parent agent should revise the code
+- `blocked` when required context is missing or the boundary cannot be reviewed responsibly
+
+The generated prompt embeds the full DDD and Hexagonal Architecture rules so it works even when the review runner has no local Tenets CLI available at review time. `npx tenets update` refreshes this agent prompt along with any other installed integrations.
+
+For Claude Code, install it together with the Claude integration:
+
+```bash
+npx tenets init --claude --code-review-agent
+```
+
+This also writes `.claude/agents/code-review-agent.md` and adds a `PostToolUse` agent hook to `.claude/settings.json`. After Claude edits a file with `Edit`, `MultiEdit`, or `Write`, Claude Code runs the Tenets code review verifier and feeds any `changes_requested` feedback back to Claude so it can revise the code before continuing.
+
+To confirm Claude Code can see it:
+
+- Run `/agents` and look for `code-review-agent`
+- Inspect `.claude/settings.json` for a `PostToolUse` hook with `type: "agent"`
+- Start Claude Code with `claude --debug` or `claude --debug-file <path>` and edit a file; the debug log will show the `PostToolUse` hook firing
 
 ---
 

--- a/cli/bin/tenets.js
+++ b/cli/bin/tenets.js
@@ -42,6 +42,8 @@ Init options:
   --claude          Claude Code (rules + skill + hook integration)
   --cursor          Write to .cursorrules
   --copilot         Write to .github/copilot-instructions.md
+  --code-review-agent
+                    Write a code review agent prompt
   --agents          Write to AGENTS.md
   --speckit         Install DDD preset into an existing Spec-Kit project
 
@@ -51,6 +53,8 @@ Claude-specific options:
 Examples:
   npx tenets init --claude
   npx tenets init --claude --with-hook
+  npx tenets init --claude --code-review-agent
+  npx tenets init --code-review-agent
   npx tenets init --cursor
   npx tenets init --speckit
   npx tenets init --claude --speckit

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tenets",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "description": "Install DDD + Hexagonal Architecture rules into your AI coding tool's config",
   "bin": {
     "tenets": "./bin/tenets.js"
@@ -14,6 +14,7 @@
     "hexagonal-architecture",
     "coding-standards",
     "ai-agents",
+    "code-review-agent",
     "claude",
     "cursor",
     "copilot",
@@ -32,6 +33,7 @@
   "files": [
     "bin/",
     "src/",
-    "bundled/"
+    "bundled/",
+    "templates/"
   ]
 }

--- a/cli/src/commands/init.js
+++ b/cli/src/commands/init.js
@@ -2,9 +2,19 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { execSync } = require('node:child_process');
 const { TOOLS } = require('../constants');
-const { fetchContent, assembleContent, computeHash, computeClaudeHash } = require('../services/content-fetcher');
+const {
+  fetchContent,
+  assembleContent,
+  assembleCodeReviewAgentContent,
+  computeHash,
+  computeClaudeHash,
+} = require('../services/content-fetcher');
 const { writeFile } = require('../services/file-writer');
-const { writeClaudeIntegration, writeHookSettings } = require('../services/claude-writer');
+const {
+  writeClaudeIntegration,
+  writeHookSettings,
+  writeCodeReviewAgentHookSettings,
+} = require('../services/claude-writer');
 const { updateToolEntry, updateSpeckitEntry } = require('../services/config-tracker');
 const { promptToolSelection, promptFileConflict, promptYesNo } = require('../ui/prompts');
 const { logger } = require('../ui/logger');
@@ -13,13 +23,10 @@ const SPECKIT_PRESET_ID = 'tenets-ddd';
 const SPECKIT_PRESET_RELEASE_URL =
   'https://github.com/bardiakhosravi/ai-agent-backend-standards/releases/latest/download/tenets-speckit-preset.zip';
 
-function resolveToolFromFlags(args) {
-  for (const [key, tool] of Object.entries(TOOLS)) {
-    if (args.includes(tool.flag)) {
-      return key;
-    }
-  }
-  return null;
+function resolveToolsFromFlags(args) {
+  return Object.entries(TOOLS)
+    .filter(([, tool]) => args.includes(tool.flag))
+    .map(([key]) => key);
 }
 
 function isCommandAvailable(cmd) {
@@ -193,35 +200,47 @@ async function initCommand(args) {
     if (!hasToolFlag) return;
   }
 
-  let toolKey = resolveToolFromFlags(args);
+  let toolKeys = resolveToolsFromFlags(args);
 
-  if (!toolKey) {
-    toolKey = await promptToolSelection(TOOLS);
+  if (toolKeys.length === 0) {
+    const toolKey = await promptToolSelection(TOOLS);
     if (!toolKey) {
       logger.error('Invalid selection. Aborting.');
       process.exitCode = 1;
       return;
     }
+    toolKeys = [toolKey];
   }
-
-  const tool = TOOLS[toolKey];
 
   const content = await fetchContent();
   const assembled = assembleContent(content);
 
-  if (tool.multiOutput) {
-    const hash = computeClaudeHash(assembled);
-    await initClaudeMultiOutput(args, toolKey, tool, content, hash);
-  } else {
-    const hash = computeHash(assembled);
-    await initSingleFile(toolKey, tool, assembled, hash);
+  const installCodeReviewAgentForClaude =
+    toolKeys.includes('claude') && toolKeys.includes('codeReviewAgent');
+
+  for (const toolKey of toolKeys) {
+    const tool = TOOLS[toolKey];
+
+    if (tool.codeReviewAgent) {
+      const codeReviewAgentContent = assembleCodeReviewAgentContent(assembled);
+      const hash = computeHash(codeReviewAgentContent);
+      await initSingleFile(toolKey, tool, codeReviewAgentContent, hash);
+    } else if (tool.multiOutput) {
+      const hash = computeClaudeHash(assembled);
+      await initClaudeMultiOutput(args, toolKey, tool, content, hash, {
+        installCodeReviewAgent: installCodeReviewAgentForClaude,
+      });
+    } else {
+      const hash = computeHash(assembled);
+      await initSingleFile(toolKey, tool, assembled, hash);
+    }
   }
 }
 
 /**
  * Claude Code: writes rules files, CLAUDE.md snippet, skill, and optionally hook config.
  */
-async function initClaudeMultiOutput(args, toolKey, tool, content, hash) {
+async function initClaudeMultiOutput(args, toolKey, tool, content, hash, options = {}) {
   const projectRoot = process.cwd();
   const rulesDir = path.resolve(projectRoot, '.claude', 'rules');
 
@@ -235,7 +254,7 @@ async function initClaudeMultiOutput(args, toolKey, tool, content, hash) {
     }
   }
 
-  const { writtenFiles, claudeMdAction } = writeClaudeIntegration(projectRoot, content);
+  const { writtenFiles, claudeMdAction } = writeClaudeIntegration(projectRoot, content, options);
 
   if (claudeMdAction === 'appended') {
     logger.info('Appending Tenets block to existing CLAUDE.md.');
@@ -258,6 +277,13 @@ async function initClaudeMultiOutput(args, toolKey, tool, content, hash) {
     writtenFiles.push(settingsFile);
   }
 
+  if (options.installCodeReviewAgent) {
+    const settingsFile = writeCodeReviewAgentHookSettings(projectRoot);
+    if (!writtenFiles.includes(settingsFile)) {
+      writtenFiles.push(settingsFile);
+    }
+  }
+
   updateToolEntry(toolKey, tool.targetFile, hash, 'multi');
 
   logger.blank();
@@ -275,6 +301,10 @@ async function initClaudeMultiOutput(args, toolKey, tool, content, hash) {
   if (installHook) {
     logger.dim('  .claude/hooks/...            Continuous monitoring hook');
     logger.dim('  .claude/settings.json        Hook configuration');
+  }
+  if (options.installCodeReviewAgent) {
+    logger.dim('  .claude/agents/code-review-agent.md  Automatic Tenets code review subagent');
+    logger.dim('  .claude/settings.json              PostToolUse agent hook for code review feedback');
   }
   logger.blank();
   logger.info('Usage:');

--- a/cli/src/commands/update.js
+++ b/cli/src/commands/update.js
@@ -3,9 +3,19 @@ const path = require('node:path');
 const { execSync } = require('node:child_process');
 const { TOOLS } = require('../constants');
 const { readConfig, updateToolEntry, updateSpeckitEntry, getSpeckitEntries, needsMigration, markMigrationDeclined, isMigrationDeclined } = require('../services/config-tracker');
-const { fetchContent, assembleContent, computeHash, computeClaudeHash } = require('../services/content-fetcher');
+const {
+  fetchContent,
+  assembleContent,
+  assembleCodeReviewAgentContent,
+  computeHash,
+  computeClaudeHash,
+} = require('../services/content-fetcher');
 const { writeFile, replaceMarkedContent } = require('../services/file-writer');
-const { writeClaudeIntegration, writeHookSettings } = require('../services/claude-writer');
+const {
+  writeClaudeIntegration,
+  writeHookSettings,
+  writeCodeReviewAgentHookSettings,
+} = require('../services/claude-writer');
 const { promptYesNo } = require('../ui/prompts');
 const { logger } = require('../ui/logger');
 
@@ -88,14 +98,16 @@ async function updateCommand() {
 
   const content = await fetchContent();
   const assembled = assembleContent(content);
+  const codeReviewAgentContent = assembleCodeReviewAgentContent(assembled);
   const baseHash = computeHash(assembled);
+  const codeReviewAgentHash = computeHash(codeReviewAgentContent);
   const claudeHash = computeClaudeHash(assembled);
 
   let updatedCount = 0;
 
   for (const [toolKey, entry] of Object.entries(config.tools)) {
     const tool = TOOLS[toolKey];
-    const newHash = tool?.multiOutput ? claudeHash : baseHash;
+    const newHash = tool?.codeReviewAgent ? codeReviewAgentHash : tool?.multiOutput ? claudeHash : baseHash;
 
     // --- Migration check: v1 single-file -> v2 multi-output ---
     if (tool?.multiOutput && needsMigration(config, toolKey)) {
@@ -117,9 +129,29 @@ async function updateCommand() {
       continue;
     }
 
-    if (tool?.multiOutput) {
+    if (tool?.codeReviewAgent) {
+      const targetFile = entry.targetFile || tool.targetFile;
+      const targetPath = path.resolve(process.cwd(), targetFile);
+      const replaced = replaceMarkedContent(targetPath, codeReviewAgentContent);
+
+      if (replaced) {
+        logger.success(`${targetFile} — updated (marker replacement).`);
+      } else {
+        writeFile(targetPath, codeReviewAgentContent, entry.mode || 'replace');
+        logger.success(`${targetFile} — updated (full ${entry.mode || 'replace'}).`);
+      }
+    } else if (tool?.multiOutput) {
       const projectRoot = process.cwd();
-      const { writtenFiles, claudeMdAction } = writeClaudeIntegration(projectRoot, content);
+      const installCodeReviewAgent = Boolean(config.tools.codeReviewAgent);
+      const { writtenFiles, claudeMdAction } = writeClaudeIntegration(projectRoot, content, {
+        installCodeReviewAgent,
+      });
+      if (installCodeReviewAgent) {
+        const settingsFile = writeCodeReviewAgentHookSettings(projectRoot);
+        if (!writtenFiles.includes(settingsFile)) {
+          writtenFiles.push(settingsFile);
+        }
+      }
       if (claudeMdAction === 'appended') {
         logger.info('Appending Tenets block to existing CLAUDE.md.');
       }

--- a/cli/src/constants.js
+++ b/cli/src/constants.js
@@ -72,6 +72,12 @@ const TOOLS = {
     flag: '--copilot',
     targetFile: '.github/copilot-instructions.md',
   },
+  codeReviewAgent: {
+    name: 'Tenets Code Review Agent',
+    flag: '--code-review-agent',
+    targetFile: '.tenets/agents/code-review-agent.md',
+    codeReviewAgent: true,
+  },
   agents: {
     name: 'AGENTS.md',
     flag: '--agents',
@@ -216,6 +222,11 @@ Group violations by severity:
 If no violations are found, confirm the code is compliant and note any particularly well-implemented patterns.
 `;
 
+const CODE_REVIEW_AGENT_NAME = 'code-review-agent';
+const CODE_REVIEW_AGENT_TEMPLATE = 'templates/agents/code-review-agent.md';
+const CLAUDE_CODE_REVIEW_AGENT_TEMPLATE = 'templates/claude/agents/code-review-agent.md';
+const CODE_REVIEW_AGENT_HOOK_PROMPT_TEMPLATE = 'templates/claude/hooks/code-review-agent-prompt.md';
+
 const CLAUDE_HOOK_SCRIPT = `#!/usr/bin/env node
 /**
  * PostToolUse hook for tenets architecture monitoring.
@@ -261,5 +272,9 @@ module.exports = {
   CLAUDE_RULE_DEFINITIONS,
   CLAUDE_MD_SNIPPET,
   CLAUDE_SKILL_CONTENT,
+  CODE_REVIEW_AGENT_NAME,
+  CODE_REVIEW_AGENT_TEMPLATE,
+  CLAUDE_CODE_REVIEW_AGENT_TEMPLATE,
+  CODE_REVIEW_AGENT_HOOK_PROMPT_TEMPLATE,
   CLAUDE_HOOK_SCRIPT,
 };

--- a/cli/src/services/claude-writer.js
+++ b/cli/src/services/claude-writer.js
@@ -5,8 +5,17 @@ const {
   CLAUDE_RULE_DEFINITIONS,
   CLAUDE_MD_SNIPPET,
   CLAUDE_SKILL_CONTENT,
+  CODE_REVIEW_AGENT_NAME,
+  CLAUDE_CODE_REVIEW_AGENT_TEMPLATE,
+  CODE_REVIEW_AGENT_HOOK_PROMPT_TEMPLATE,
   CLAUDE_HOOK_SCRIPT,
 } = require('../constants');
+
+const CLI_ROOT = path.join(__dirname, '..', '..');
+
+function readCliFile(relativePath) {
+  return fs.readFileSync(path.join(CLI_ROOT, relativePath), 'utf-8');
+}
 
 function ensureDir(dirPath) {
   if (!fs.existsSync(dirPath)) {
@@ -45,9 +54,11 @@ function buildRuleFile(definition, sections) {
  * 2. CLAUDE.md snippet          — top-level principles (appended/replaced)
  * 3. .claude/skills/tenets-review-architecture/SKILL.md — on-demand review command
  * 4. .claude/hooks/check-architecture.js — continuous monitoring hook
+ * 5. .claude/agents/code-review-agent.md — optional Claude Code subagent
  */
-function writeClaudeIntegration(projectRoot, content) {
+function writeClaudeIntegration(projectRoot, content, options = {}) {
   const { sections } = content;
+  const { installCodeReviewAgent = false } = options;
   const writtenFiles = [];
 
   // --- Layer 1: Rule files ---
@@ -92,6 +103,14 @@ function writeClaudeIntegration(projectRoot, content) {
   const oldSkillDir = path.join(projectRoot, '.claude', 'skills', 'review-architecture');
   if (fs.existsSync(oldSkillDir)) {
     fs.rmSync(oldSkillDir, { recursive: true });
+  }
+
+  if (installCodeReviewAgent) {
+    const agentDir = path.join(projectRoot, '.claude', 'agents');
+    ensureDir(agentDir);
+    const agentPath = path.join(agentDir, `${CODE_REVIEW_AGENT_NAME}.md`);
+    fs.writeFileSync(agentPath, readCliFile(CLAUDE_CODE_REVIEW_AGENT_TEMPLATE), 'utf-8');
+    writtenFiles.push(`.claude/agents/${CODE_REVIEW_AGENT_NAME}.md`);
   }
 
   // --- Layer 4: Hook script ---
@@ -177,4 +196,48 @@ function writeHookSettings(projectRoot) {
   return '.claude/settings.json';
 }
 
-module.exports = { writeClaudeIntegration, writeHookSettings };
+function writeCodeReviewAgentHookSettings(projectRoot) {
+  const settingsPath = path.join(projectRoot, '.claude', 'settings.json');
+
+  let settings = {};
+  if (fs.existsSync(settingsPath)) {
+    try {
+      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    } catch {
+      settings = {};
+    }
+  }
+
+  if (!settings.hooks) {
+    settings.hooks = {};
+  }
+
+  if (!settings.hooks.PostToolUse) {
+    settings.hooks.PostToolUse = [];
+  }
+
+  const tenetsCodeReviewHookExists = settings.hooks.PostToolUse.some((entry) =>
+    entry.hooks?.some((h) => h.type === 'agent' && h.prompt?.includes('Tenets code review agent'))
+  );
+
+  if (!tenetsCodeReviewHookExists) {
+    settings.hooks.PostToolUse.push({
+      matcher: 'Edit|MultiEdit|Write',
+      hooks: [
+        {
+          type: 'agent',
+          prompt: readCliFile(CODE_REVIEW_AGENT_HOOK_PROMPT_TEMPLATE).trim(),
+          timeout: 120,
+          continueOnBlock: true,
+        },
+      ],
+    });
+  }
+
+  ensureDir(path.dirname(settingsPath));
+  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
+
+  return '.claude/settings.json';
+}
+
+module.exports = { writeClaudeIntegration, writeHookSettings, writeCodeReviewAgentHookSettings };

--- a/cli/src/services/content-fetcher.js
+++ b/cli/src/services/content-fetcher.js
@@ -1,10 +1,21 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const crypto = require('node:crypto');
-const { GITHUB_RAW_BASE, INTRODUCTION_FILE, CONTENT_SECTIONS, MARKERS } = require('../constants');
+const {
+  GITHUB_RAW_BASE,
+  INTRODUCTION_FILE,
+  CONTENT_SECTIONS,
+  MARKERS,
+  CODE_REVIEW_AGENT_TEMPLATE,
+} = require('../constants');
 const { logger } = require('../ui/logger');
 
 const BUNDLED_DIR = path.join(__dirname, '..', '..', 'bundled');
+const CLI_ROOT = path.join(__dirname, '..', '..');
+
+function readCliFile(relativePath) {
+  return fs.readFileSync(path.join(CLI_ROOT, relativePath), 'utf-8');
+}
 
 async function fetchUrl(url) {
   const controller = new AbortController();
@@ -99,6 +110,25 @@ function assembleContent({ introduction, sections }) {
   return parts.join('\n');
 }
 
+function stripTenetsMarkers(content) {
+  return content
+    .replace(MARKERS.start, '')
+    .replace(MARKERS.end, '')
+    .trim();
+}
+
+/**
+ * Assemble a standalone prompt for a repository-installed code review agent.
+ * This file is intentionally tool-agnostic: any local or remote parent agent can
+ * load it as the review agent's system/project instructions.
+ */
+function assembleCodeReviewAgentContent(assembledRules) {
+  const rulebook = stripTenetsMarkers(assembledRules);
+  const template = readCliFile(CODE_REVIEW_AGENT_TEMPLATE);
+
+  return `${MARKERS.start}\n${template.replace('{{TENETS_RULEBOOK}}', rulebook).trim()}\n${MARKERS.end}\n`;
+}
+
 function computeHash(content) {
   return crypto.createHash('sha256').update(content).digest('hex');
 }
@@ -110,9 +140,30 @@ function computeHash(content) {
  * the change even if the rule content hasn't changed.
  */
 function computeClaudeHash(assembled) {
-  const { CLAUDE_MD_SNIPPET, CLAUDE_SKILL_CONTENT, CLAUDE_HOOK_SCRIPT } = require('../constants');
-  const combined = assembled + '\n---CLI_TEMPLATES---\n' + CLAUDE_MD_SNIPPET + CLAUDE_SKILL_CONTENT + CLAUDE_HOOK_SCRIPT;
+  const {
+    CLAUDE_MD_SNIPPET,
+    CLAUDE_SKILL_CONTENT,
+    CLAUDE_CODE_REVIEW_AGENT_TEMPLATE,
+    CODE_REVIEW_AGENT_HOOK_PROMPT_TEMPLATE,
+    CLAUDE_HOOK_SCRIPT,
+  } = require('../constants');
+  const codeReviewAgentTemplate = readCliFile(CLAUDE_CODE_REVIEW_AGENT_TEMPLATE);
+  const codeReviewHookPromptTemplate = readCliFile(CODE_REVIEW_AGENT_HOOK_PROMPT_TEMPLATE);
+  const combined =
+    assembled +
+    '\n---CLI_TEMPLATES---\n' +
+    CLAUDE_MD_SNIPPET +
+    CLAUDE_SKILL_CONTENT +
+    codeReviewAgentTemplate +
+    codeReviewHookPromptTemplate +
+    CLAUDE_HOOK_SCRIPT;
   return computeHash(combined);
 }
 
-module.exports = { fetchContent, assembleContent, computeHash, computeClaudeHash };
+module.exports = {
+  fetchContent,
+  assembleContent,
+  assembleCodeReviewAgentContent,
+  computeHash,
+  computeClaudeHash,
+};

--- a/cli/templates/agents/code-review-agent.md
+++ b/cli/templates/agents/code-review-agent.md
@@ -1,0 +1,79 @@
+# Tenets Code Review Agent
+
+You are a repository-installed code review agent for a codebase that follows Hexagonal Architecture and Domain-Driven Design.
+
+## Mission
+
+Review code produced by a parent coding agent and give actionable feedback before that work is treated as complete. Your job is not to rewrite the feature by default. Your job is to identify where the implementation violates Tenets rules, explain the risk, and give the parent agent a clear repair plan.
+
+## Operating Model
+
+- Run after the parent agent finishes a feature, bug fix, refactor, or generated code change.
+- Review the diff and any files needed to understand architectural boundaries.
+- Prefer concrete evidence from code over broad architectural advice.
+- Treat this file as the canonical review contract for Tenets compliance.
+- Do not approve work that violates dependency direction, domain purity, aggregate invariants, or port/adapter boundaries.
+- If the repository has additional local instructions such as AGENTS.md, CLAUDE.md, or .github/copilot-instructions.md, follow them as well.
+
+## Review Workflow
+
+1. Identify changed files and classify each by layer: domain, application, primary adapter, secondary adapter, infrastructure, configuration, tests, or documentation.
+2. Load the relevant Tenets rules from the rulebook below.
+3. Check imports, dependencies, data flow, and business logic placement.
+4. Inspect tests for the changed behavior and the changed layer.
+5. Produce feedback using the parent-agent feedback contract below.
+
+## Parent-Agent Feedback Contract
+
+Return feedback in this shape:
+
+### Status
+
+Use exactly one:
+
+- `pass`: no blocking Tenets issues found.
+- `changes_requested`: fixable issues found; parent agent should revise the code.
+- `blocked`: the implementation cannot be reviewed responsibly because required context is missing or the architecture boundary is unclear.
+
+### Scope Reviewed
+
+List the changed paths and any supporting files you inspected.
+
+### Findings
+
+For each finding include:
+
+- Severity: `critical`, `major`, or `minor`
+- File and line when available
+- Rule violated
+- What is wrong
+- Why it matters
+- Specific fix for the parent agent
+
+### Repair Plan
+
+Give the parent agent a concise ordered list of code changes to make. Keep it implementation-oriented.
+
+### Questions
+
+Ask only questions that block a correct architectural decision.
+
+## Severity Guide
+
+- `critical`: dependency direction violations, framework or infrastructure leakage into domain, aggregate invariant bypasses, circular dependencies across layers.
+- `major`: business logic in adapters or use cases, missing ports around external systems, repository implementations leaking persistence models, inadequate tests for changed domain/application behavior.
+- `minor`: naming drift from ubiquitous language, project structure issues, missing ADR for a justified exception, local cleanup that improves maintainability.
+
+## Non-Negotiable Checks
+
+- Domain code must not import frameworks, ORMs, HTTP clients, queues, databases, or adapter modules.
+- Application use cases orchestrate workflows; they do not own business rules.
+- External systems are accessed through ports, not directly from domain or use cases.
+- Adapters translate, validate transport concerns, map data, and delegate; they do not make domain decisions.
+- Aggregates protect invariants and are the entry point for state changes inside their consistency boundary.
+- Domain events use ubiquitous language and do not mention vendors or infrastructure.
+- Tests should match the layer: domain unit tests, use-case orchestration tests with fakes, adapter contract/integration tests at the boundary.
+
+## Full Tenets Rulebook
+
+{{TENETS_RULEBOOK}}

--- a/cli/templates/claude/agents/code-review-agent.md
+++ b/cli/templates/claude/agents/code-review-agent.md
@@ -1,0 +1,46 @@
+---
+name: code-review-agent
+description: Use proactively after code edits to review Tenets Hexagonal Architecture and DDD compliance and give actionable feedback to the parent agent.
+tools: Read, Grep, Glob, Bash
+model: inherit
+color: cyan
+---
+
+You are the Tenets code review agent for this repository. Review code written by the parent agent and give concise, actionable architecture feedback.
+
+## Operating Rules
+
+- You are read-only. Do not edit files.
+- Load all Tenets rules from `.claude/rules/tenets-*.md` before making architecture judgments.
+- Prefer direct evidence from changed code over general advice.
+- Focus on Hexagonal Architecture, Domain-Driven Design, dependency direction, domain purity, aggregate invariants, ports, adapters, and tests.
+- If hook input identifies a specific edited file, start there, then inspect nearby files needed to understand the boundary.
+- Use `git diff -- <path>` when available to understand the current change.
+
+## Feedback Contract
+
+Return exactly these sections:
+
+### Status
+
+Use one of:
+
+- `pass`: no blocking Tenets issues found.
+- `changes_requested`: fixable issues found; parent agent should revise the code.
+- `blocked`: required context is missing or the architecture boundary cannot be reviewed responsibly.
+
+### Scope Reviewed
+
+List the changed paths and any supporting files inspected.
+
+### Findings
+
+For each finding include severity, file/line when available, rule violated, what is wrong, why it matters, and the specific fix.
+
+### Repair Plan
+
+Give the parent agent an ordered list of concrete changes to make. If status is `pass`, write `None`.
+
+### Questions
+
+Ask only questions that block a correct architectural decision. If none, write `None`.

--- a/cli/templates/claude/hooks/code-review-agent-prompt.md
+++ b/cli/templates/claude/hooks/code-review-agent-prompt.md
@@ -1,0 +1,18 @@
+You are the Tenets code review agent running as a Claude Code PostToolUse verifier after a file edit.
+
+Hook input:
+$ARGUMENTS
+
+Task:
+1. Identify the edited file path from the hook input.
+2. If the path is not source, test, application, domain, adapter, infrastructure, configuration, or architecture-relevant code, return {"ok": true}.
+3. Read .claude/rules/tenets-*.md.
+4. Inspect the edited file and nearby files needed to understand its layer and dependency boundary.
+5. Review only for Tenets Hexagonal Architecture and DDD compliance.
+
+Return JSON only:
+- {"ok": true, "reason": "pass: <brief scope reviewed>"} when there are no blocking architecture concerns.
+- {"ok": false, "reason": "changes_requested: <specific findings and repair plan for the parent agent>"} when Claude should revise the code before continuing.
+- {"ok": false, "reason": "blocked: <missing context or unclear boundary>"} when review cannot be done responsibly.
+
+Keep the reason concise but concrete. Include file paths and line numbers when available.


### PR DESCRIPTION
## Summary

Adds a Tenets code review agent install target that can be used standalone or wired into Claude Code as an automatic architecture reviewer after file edits.

## Type of Change

- [ ] Rule improvement (clarification, examples, better explanation)
- [ ] New rule addition
- [x] Documentation update
- [ ] Example implementation
- [ ] Bug fix
- [x] Other: CLI feature

## Changes Made

- Adds `npx tenets init --code-review-agent`, which writes `.tenets/agents/code-review-agent.md`.
- Adds Claude Code integration for `npx tenets init --claude --code-review-agent`, writing `.claude/agents/code-review-agent.md` and a `PostToolUse` agent hook.
- Moves the code review agent prompt content into template files under `cli/templates/`.
- Updates `tenets update` so installed code review agent prompts and Claude hook wiring stay current.
- Bumps the CLI package version to `0.7.0`.

## Checklist

- [x] I have read the CONTRIBUTING.md guidelines
- [x] My changes follow the existing format and style
- [x] I have tested any code examples (if applicable)
- [x] I have updated documentation as needed
- [x] I have considered how AI agents will interpret these rules

## Additional Context

This PR intentionally excludes the in-progress ubiquitous-language skill work. It does not add `skills/`, `cli/bundled/skills/`, or remove the existing ubiquitous-language rule file.

Smoke-tested:

- `node -c` on changed JS files
- `tenets init --code-review-agent`
- `tenets init --claude --code-review-agent --with-hook`
- `tenets update`
